### PR TITLE
Check and publish dbt JSON schemas

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -350,7 +350,7 @@ jobs:
           ref: ${{ needs.create-commit.outputs.DBT_RELEASE_BRANCH }}
           path: ./build/dbt
       - name: Run check
-        run: /bin/bash scripts/script_shim.bash native schemas check
+        run: /bin/bash scripts/script_shim.bash schemas check
   all-tests:
     name: All tests requirement
     needs:
@@ -572,7 +572,7 @@ jobs:
           ref: ${{ needs.create-commit.outputs.DBT_RELEASE_BRANCH }}
           path: ./build/dbt
       - name: Publish schemas to schemas.getdbt.com
-        run: /bin/bash scripts/script_shim.bash native schemas publish
+        run: /bin/bash scripts/script_shim.bash schemas publish
   create-github-release:
     name: Create the github release
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -328,6 +328,29 @@ jobs:
         with:
           name: homebrew-template
           path: ./artifacts/homebrew_template.pickle
+  test-artifact-schema:
+    name: Check for breaking schema changes to dbt artifacts
+    needs: [create-commit, build-wheels]
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Make sure the release branch build arg is non-empty
+        run: |
+          [[ -n "${{ needs.create-commit.outputs.DBT_RELEASE_BRANCH }}" ]]
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - run: mkdir build && mkdir artifacts
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Check out dbt
+        uses: actions/checkout@v2
+        with:
+          repository: fishtown-analytics/dbt
+          ref: ${{ needs.create-commit.outputs.DBT_RELEASE_BRANCH }}
+          path: ./build/dbt
+      - name: Run check
+        run: /bin/bash scripts/script_shim.bash native schemas check
   all-tests:
     name: All tests requirement
     needs:
@@ -337,6 +360,7 @@ jobs:
         test-redshift,
         test-snowflake,
         test-homebrew-formula,
+        test-artifact-schema,
       ]
     runs-on: ubuntu-18.04
     steps:
@@ -521,6 +545,34 @@ jobs:
           SNOWFLAKE_TEST_USER: public_integration_test_user
           SNOWFLAKE_TEST_WAREHOUSE: DBT_TEST
         run: /bin/bash scripts/script_shim.bash homebrew upload
+  publish-artifact-schema:
+    name: Upload schemas for dbt artifacts
+    needs: [merge-release-branch, upload-wheels]
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Make sure the release branch build arg is non-empty
+        run: |
+          [[ -n "${{ needs.create-commit.outputs.DBT_RELEASE_BRANCH }}" ]]
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - run: mkdir build && mkdir artifacts
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Download releasefile
+        uses: actions/download-artifact@v2
+        with:
+          name: releasefile
+          path: artifacts/
+      - name: Check out dbt
+        uses: actions/checkout@v2
+        with:
+          repository: fishtown-analytics/dbt
+          ref: ${{ needs.create-commit.outputs.DBT_RELEASE_BRANCH }}
+          path: ./build/dbt
+      - name: Publish schemas to schemas.getdbt.com
+        run: /bin/bash scripts/script_shim.bash native schemas publish
   create-github-release:
     name: Create the github release
     needs:
@@ -529,6 +581,7 @@ jobs:
         upload-wheels,
         upload-homebrew-formula,
         upload-docker-image,
+        publish-artifact-schema,
       ]
     runs-on: ubuntu-18.04
     steps:

--- a/scripts/release-pypath/builder/artifact_schemas.py
+++ b/scripts/release-pypath/builder/artifact_schemas.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from .common import EnvironmentInformation, ReleaseFile
 from .git import ArtifactSchemaRepository
 from .cmd import stream_output, collect_output
-from .virtualenvs import ArtifactDiffEnv
+from .virtualenvs import SchemaArtifactEnv
 from urllib.request import urlopen
 from typing import List
 
@@ -120,7 +120,7 @@ footer {{
 
 def check_artifact_schema(args=None):
     env = EnvironmentInformation()
-    artifact_env = ArtifactDiffEnv(env.dbt_dir / "requirements.txt")
+    artifact_env = SchemaArtifactEnv(env.dbt_dir / "requirements.txt")
     artifact_env.create(env.schemas_venv)
     pip = str(env.schemas_venv / "bin/pip")
     cmd = [pip, "install", "-r", "requirements.txt"]
@@ -182,7 +182,7 @@ def check_artifact_schema(args=None):
 def publish_artifact_schema(args=None):
     env = EnvironmentInformation()
     release = ReleaseFile.from_artifacts(env)
-    artifact_env = ArtifactDiffEnv(env.dbt_dir / "requirements.txt")
+    artifact_env = SchemaArtifactEnv(env.dbt_dir / "requirements.txt")
     artifact_env.create(env.schemas_venv)
     pip = str(env.schemas_venv / "bin/pip")
     cmd = [pip, "install", "-r", "requirements.txt"]

--- a/scripts/release-pypath/builder/artifact_schemas.py
+++ b/scripts/release-pypath/builder/artifact_schemas.py
@@ -1,0 +1,105 @@
+import json
+import tempfile
+from pathlib import Path
+from .common import EnvironmentInformation, ReleaseFile
+from .git import ArtifactSchemaRepository
+from .cmd import stream_output, collect_output
+from .virtualenvs import ArtifactDiffEnv
+from urllib.request import urlopen
+
+
+def check_artifact_schema(args=None):
+    env = EnvironmentInformation()
+    artifact_env = ArtifactDiffEnv(env.dbt_dir / "requirements.txt")
+    artifact_env.create(env.schemas_venv)
+    pip = str(env.schemas_venv / "bin/pip")
+    cmd = [pip, "install", "-r", "requirements.txt"]
+    stream_output(cmd, cwd=env.dbt_dir)
+
+    python_path = str(env.schemas_venv / "bin/python")
+    stream_output(
+        cmd=[
+            python_path,
+            "scripts/collect-artifact-schema.py",
+            "--path",
+            env.build_dir / "schemas"
+        ],
+        cwd=env.dbt_dir
+    )
+
+    deep_diff_path = str(env.schemas_venv / "bin/deep")
+    artifact_files = Path(env.build_dir / "schemas").glob('**/*.json')
+    for schema_file_path in artifact_files:
+        with open(schema_file_path) as f:
+            schema_data = json.load(f)
+            url = schema_data["$id"]
+            with urlopen(url) as fp, tempfile.NamedTemporaryFile(suffix='.json') as temp_fp:
+                temp_fp.write(fp.read())
+
+                cmd = [
+                    deep_diff_path,
+                    "diff",
+                    schema_file_path,
+                    temp_fp.name,
+                    "--ignore-order",
+                    "--exclude-regex-paths",
+                    "\\['dbt_version'\\]\\['default'\\]|\\['generated_at'\\]\\['default'\\]|\\['description'\\]"
+                ]
+                results = collect_output(cmd).strip()
+                if results != '{}':
+                    raise ValueError(
+                        f"There are breaking changes to artifact schema {url}:\n{results}")
+
+
+def publish_artifact_schema(args=None):
+    env = EnvironmentInformation()
+    release = ReleaseFile.from_artifacts(env)
+    artifact_env = ArtifactDiffEnv(env.dbt_dir / "requirements.txt")
+    artifact_env.create(env.schemas_venv)
+    pip = str(env.schemas_venv / "bin/pip")
+    cmd = [pip, "install", "-r", "requirements.txt"]
+    stream_output(cmd, cwd=env.dbt_dir)
+
+    artifact_schema_repo = ArtifactSchemaRepository(env.schemas_checkout_path)
+    artifact_schema_repo.clone()
+
+    python_path = str(env.schemas_venv / "bin/python")
+    stream_output(
+        cmd=[
+            python_path,
+            "scripts/collect-artifact-schema.py",
+            "--path",
+            env.schemas_checkout_path
+        ],
+        cwd=env.dbt_dir
+    )
+
+    stream_output(
+        ["git", "add", env.schemas_checkout_path / "dbt"], cwd=env.schemas_checkout_path
+    )
+    stream_output(
+        ["git", "commit", "-m", f"artifact schema updates for dbt@{release.version}"], cwd=env.schemas_checkout_path
+    )
+
+    if args is None or args.push_updates:
+        artifact_schema_repo.push_updates()
+
+
+def add_artifact_schema_parsers(subparsers):
+    artifact_schema_sub = subparsers.add_parser(
+        "schemas", help="generate/check artifact schema")
+    artifact_schema_subs = artifact_schema_sub.add_subparsers(
+        title="Available sub-commands")
+
+    check_sub = artifact_schema_subs.add_parser(
+        "check",
+        help=(
+            "Generates artifact schema and diff against published artifact schemas"
+        ),
+    )
+    check_sub.set_defaults(func=check_artifact_schema)
+
+    publish_sub = artifact_schema_subs.add_parser(
+        "publish", help="Publish artifact schema to schemas.getdbt.com")
+    publish_sub.add_argument("--no-push", dest="push_updates", action="store_false")
+    publish_sub.set_defaults(func=publish_artifact_schema)

--- a/scripts/release-pypath/builder/artifact_schemas.py
+++ b/scripts/release-pypath/builder/artifact_schemas.py
@@ -1,3 +1,6 @@
+import re
+from dataclasses import dataclass
+import textwrap
 import json
 import tempfile
 from pathlib import Path
@@ -6,6 +9,113 @@ from .git import ArtifactSchemaRepository
 from .cmd import stream_output, collect_output
 from .virtualenvs import ArtifactDiffEnv
 from urllib.request import urlopen
+from typing import List
+
+
+@dataclass
+class SchemaInfo:
+    name: str
+    json_path: Path
+    docs_path: Path
+
+    def render(self) -> str:
+        result = textwrap.dedent(
+            f"""\
+            <li>
+              <a href="{self.json_path}">{self.name}</a> (<a href="{self.docs_path}">documentation</a>)
+            </li>
+        """
+        )
+        return result
+
+    def __str__(self) -> str:
+        return self.render()
+
+
+def schema_artifacts_to_html(schema_data: List[SchemaInfo]) -> str:
+    fmt = _get_index_html_template()
+
+    artifact_schema_list = "\n".join([str(artifact) for artifact in schema_data])
+
+    artifact_schema_html = textwrap.dedent(
+        f"""\
+        <ul>
+          {artifact_schema_list}
+        </ul>
+    """
+    )
+
+    return fmt.format(artifact_schema_html=artifact_schema_html)
+
+
+def _get_index_html_template() -> str:
+    return textwrap.dedent(
+        """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>dbt JSON Schema</title>
+  <style>
+body {{
+  background: #003645!important;
+  color: #93a1a1;
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+  padding: 40px 20px;
+  text-align: center;
+}}
+main {{
+  font-size: 180%;
+}}
+h1 {{
+  color: #fff;
+}}
+i {{
+  color: #719e07;
+}}
+p {{
+  margin-bottom: 2em;
+}}
+a {{
+  color: #93a1a1;
+  text-decoration: none;
+}}
+a:hover {{
+  color: #fff
+}}
+ul {{
+  list-style: none;
+  padding: 0;
+
+}}
+ul li {{
+  margin-bottom: 1em;
+}}
+footer {{
+  margin-top: 10em;
+  font-size: 140%;
+}}
+  </style>
+</head>
+<body>
+  <main>
+
+    <img src="static/dbt-logo-full-white.svg" width="150">
+    <h1>dbt JSON Schema</h1>
+
+    <p>Individual JSON Schemas for dbt artifact objects</p>
+
+    {artifact_schema_html}
+  </main>
+
+  <footer>
+    <p><a href="https://github.com/fishtown-analytics/schemas.getdbt.com">github.com/fishtown-analytics/schemas.getdbt.com</a></p>
+  </footer>
+</body>
+</html>
+"""
+    )
 
 
 def check_artifact_schema(args=None):
@@ -16,39 +126,57 @@ def check_artifact_schema(args=None):
     cmd = [pip, "install", "-r", "requirements.txt"]
     stream_output(cmd, cwd=env.dbt_dir)
 
-    python_path = str(env.schemas_venv / "bin/python")
+    python_path = env.schemas_venv / "bin/python"
+    schemas_dest_dir = env.build_dir / "schemas"
     stream_output(
         cmd=[
-            python_path,
+            str(python_path),
             "scripts/collect-artifact-schema.py",
             "--path",
-            env.build_dir / "schemas"
+            str(schemas_dest_dir),
         ],
-        cwd=env.dbt_dir
+        cwd=env.dbt_dir,
     )
 
+    artifact_schema_repo = ArtifactSchemaRepository(env.schemas_checkout_path)
+    artifact_schema_repo.clone()
+
     deep_diff_path = str(env.schemas_venv / "bin/deep")
-    artifact_files = Path(env.build_dir / "schemas").glob('**/*.json')
-    for schema_file_path in artifact_files:
+    schema_files = schemas_dest_dir.glob("**/*.json")
+    for schema_file_path in schema_files:
         with open(schema_file_path) as f:
+            relative_path = re.sub(
+                str(schemas_dest_dir) + "/", "", str(schema_file_path)
+            )
+            exists = (env.schemas_checkout_path / relative_path).exists()
+            if not exists:
+                print(f"Found new schema {relative_path}, skipping")
+                continue
             schema_data = json.load(f)
             url = schema_data["$id"]
-            with urlopen(url) as fp, tempfile.NamedTemporaryFile(suffix='.json') as temp_fp:
+            with urlopen(url) as fp, tempfile.NamedTemporaryFile(
+                suffix=".json"
+            ) as temp_fp:
                 temp_fp.write(fp.read())
-
                 cmd = [
                     deep_diff_path,
                     "diff",
-                    schema_file_path,
                     temp_fp.name,
+                    schema_file_path,
                     "--ignore-order",
                     "--exclude-regex-paths",
-                    "\\['dbt_version'\\]\\['default'\\]|\\['generated_at'\\]\\['default'\\]|\\['description'\\]"
+                    "\\['dbt_version'\\]\\['default'\\]|"
+                    "\\['generated_at'\\]\\['default'\\]|\\['description'\\]|"
+                    "\\['dbt_schema_version'\\]\\['default'\\]",
                 ]
                 results = collect_output(cmd).strip()
-                if results != '{}':
+                if results != "{}":
                     raise ValueError(
-                        f"There are breaking changes to artifact schema {url}:\n{results}")
+                        f"There are breaking changes to artifact schema {relative_path}:"
+                        f"\n{results}"
+                    )
+
+    print("No breaking changes!")
 
 
 def publish_artifact_schema(args=None):
@@ -69,16 +197,39 @@ def publish_artifact_schema(args=None):
             python_path,
             "scripts/collect-artifact-schema.py",
             "--path",
-            env.schemas_checkout_path
+            env.schemas_checkout_path,
         ],
-        cwd=env.dbt_dir
+        cwd=env.dbt_dir,
     )
 
+    # generate docs
+    generate_schema_doc_path = str(env.schemas_venv / "bin/generate-schema-doc")
+    schema_files = (env.schemas_checkout_path / "dbt").glob("**/*.json")
+    schema_data = []
+    for schema_file_path in schema_files:
+        schema_dir_path = schema_file_path.with_suffix("")
+        schema_dir_path.mkdir(exist_ok=True)
+        schema_docs_path = schema_dir_path / "index.html"
+        cmd = [generate_schema_doc_path, schema_file_path, schema_docs_path]
+        stream_output(cmd, cwd=env.schemas_checkout_path)
+        schema_data.append(
+            SchemaInfo(
+                name=str(schema_file_path.relative_to(env.schemas_checkout_path)),
+                docs_path=schema_docs_path.relative_to(env.schemas_checkout_path),
+                json_path=schema_file_path.relative_to(env.schemas_checkout_path),
+            )
+        )
+
+    index_file = env.schemas_checkout_path / "index.html"
+    index_file.write_text(schema_artifacts_to_html(schema_data))
+
     stream_output(
-        ["git", "add", env.schemas_checkout_path / "dbt"], cwd=env.schemas_checkout_path
+        ["git", "add", env.schemas_checkout_path / "dbt", index_file],
+        cwd=env.schemas_checkout_path,
     )
     stream_output(
-        ["git", "commit", "-m", f"artifact schema updates for dbt@{release.version}"], cwd=env.schemas_checkout_path
+        ["git", "commit", "-m", f"artifact schema updates for dbt@{release.version}"],
+        cwd=env.schemas_checkout_path,
     )
 
     if args is None or args.push_updates:
@@ -87,19 +238,20 @@ def publish_artifact_schema(args=None):
 
 def add_artifact_schema_parsers(subparsers):
     artifact_schema_sub = subparsers.add_parser(
-        "schemas", help="generate/check artifact schema")
+        "schemas", help="generate/check artifact schema"
+    )
     artifact_schema_subs = artifact_schema_sub.add_subparsers(
-        title="Available sub-commands")
+        title="Available sub-commands"
+    )
 
     check_sub = artifact_schema_subs.add_parser(
         "check",
-        help=(
-            "Generates artifact schema and diff against published artifact schemas"
-        ),
+        help=("Generates artifact schema and diff against published artifact schemas"),
     )
     check_sub.set_defaults(func=check_artifact_schema)
 
     publish_sub = artifact_schema_subs.add_parser(
-        "publish", help="Publish artifact schema to schemas.getdbt.com")
+        "publish", help="Publish artifact schema to schemas.getdbt.com"
+    )
     publish_sub.add_argument("--no-push", dest="push_updates", action="store_false")
     publish_sub.set_defaults(func=publish_artifact_schema)

--- a/scripts/release-pypath/builder/common.py
+++ b/scripts/release-pypath/builder/common.py
@@ -190,6 +190,14 @@ class EnvironmentInformation:
     def homebrew_checkout_path(self) -> Path:
         return self.build_dir / "homebrew-dbt"
 
+    @property
+    def schemas_checkout_path(self) -> Path:
+        return self.build_dir / "schemas.getdbt.com"
+
+    @property
+    def schemas_venv(self) -> Path:
+        return self.build_dir / "schemas_venv"
+
     def get_dbt_requirements_file(self, version: str) -> Path:
         return self.docker_dir / f"requirements/requirements.{version}.txt"
 

--- a/scripts/release-pypath/builder/git.py
+++ b/scripts/release-pypath/builder/git.py
@@ -161,3 +161,9 @@ class HomebrewRepository(Repository):
     def __init__(self, path: Path):
         url = "git@github.com:fishtown-analytics/homebrew-dbt.git"
         super().__init__(path=path, repository_url=url)
+
+
+class ArtifactSchemaRepository(Repository):
+    def __init__(self, path: Path):
+        url = "git@github.com:fishtown-analytics/schemas.getdbt.com.git"
+        super().__init__(path=path, repository_url=url)

--- a/scripts/release-pypath/builder/homebrew.py
+++ b/scripts/release-pypath/builder/homebrew.py
@@ -510,5 +510,7 @@ def add_homebrew_parsers(subparsers):
     homebrew_upload_sub = homebrew_subs.add_parser(
         "upload", help="Upload the homebrew package"
     )
-    homebrew_upload_sub.add_argument("--no-push", dest="push_updates", action="store_false")
+    homebrew_upload_sub.add_argument(
+        "--no-push", dest="push_updates", action="store_false"
+    )
     homebrew_upload_sub.set_defaults(func=homebrew_upload)

--- a/scripts/release-pypath/builder/homebrew.py
+++ b/scripts/release-pypath/builder/homebrew.py
@@ -494,8 +494,8 @@ def homebrew_upload(args=None):
     template = HomebrewTemplate.from_artifacts(env=env)
     builder.build_and_test(template=template)
 
-    # push!
-    repository.push_updates()
+    if args is None or args.push_updates:
+        repository.push_updates()
 
 
 def add_homebrew_parsers(subparsers):
@@ -510,4 +510,5 @@ def add_homebrew_parsers(subparsers):
     homebrew_upload_sub = homebrew_subs.add_parser(
         "upload", help="Upload the homebrew package"
     )
+    homebrew_upload_sub.add_argument("--no-push", dest="push_updates", action="store_false")
     homebrew_upload_sub.set_defaults(func=homebrew_upload)

--- a/scripts/release-pypath/builder/main.py
+++ b/scripts/release-pypath/builder/main.py
@@ -6,6 +6,7 @@ from .homebrew import add_homebrew_parsers
 from .native import add_native_parsers
 from .docker import add_docker_parsers
 from .github import add_github_parsers
+from .artifact_schemas import add_artifact_schema_parsers
 
 
 if sys.version_info < (3, 8):
@@ -20,6 +21,7 @@ def parse_args():
     add_homebrew_parsers(subs)
     add_docker_parsers(subs)
     add_github_parsers(subs)
+    add_artifact_schema_parsers(subs)
 
     return parser.parse_args()
 

--- a/scripts/release-pypath/builder/virtualenvs.py
+++ b/scripts/release-pypath/builder/virtualenvs.py
@@ -170,6 +170,7 @@ class ArtifactDiffEnv(EnvBuilder):
                 tmp,
                 context,
                 "deepdiff[cli]",
+                "json-schema-for-humans"
             )
 
 

--- a/scripts/release-pypath/builder/virtualenvs.py
+++ b/scripts/release-pypath/builder/virtualenvs.py
@@ -160,14 +160,19 @@ class PackagingEnv(EnvBuilder):
             )
 
 
-class ArtifactDiffEnv(EnvBuilder):
+class SchemaArtifactEnv(EnvBuilder):
     def __init__(self, requirements: Path):
         super().__init__(with_pip=True, upgrade_deps=True)
 
     def post_setup(self, context):
         with tempfile.TemporaryDirectory() as tmp:
             self.dbt_pip_install(
-                tmp, context, "deepdiff[cli]", "json-schema-for-humans"
+                tmp,
+                context,
+                "wheel",
+                "setuptools",
+                "deepdiff[cli]",
+                "json-schema-for-humans",
             )
 
 

--- a/scripts/release-pypath/builder/virtualenvs.py
+++ b/scripts/release-pypath/builder/virtualenvs.py
@@ -148,7 +148,6 @@ class PackagingEnv(EnvBuilder):
         super().__init__(with_pip=True, upgrade_deps=True)
 
     def post_setup(self, context):
-
         with tempfile.TemporaryDirectory() as tmp:
             self.dbt_pip_install(
                 tmp,
@@ -158,6 +157,19 @@ class PackagingEnv(EnvBuilder):
                 "virtualenv==20.0.3",
                 "bumpversion==0.5.3",
                 "twine",
+            )
+
+
+class ArtifactDiffEnv(EnvBuilder):
+    def __init__(self, requirements: Path):
+        super().__init__(with_pip=True, upgrade_deps=True)
+
+    def post_setup(self, context):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.dbt_pip_install(
+                tmp,
+                context,
+                "deepdiff[cli]",
             )
 
 

--- a/scripts/release-pypath/builder/virtualenvs.py
+++ b/scripts/release-pypath/builder/virtualenvs.py
@@ -167,10 +167,7 @@ class ArtifactDiffEnv(EnvBuilder):
     def post_setup(self, context):
         with tempfile.TemporaryDirectory() as tmp:
             self.dbt_pip_install(
-                tmp,
-                context,
-                "deepdiff[cli]",
-                "json-schema-for-humans"
+                tmp, context, "deepdiff[cli]", "json-schema-for-humans"
             )
 
 


### PR DESCRIPTION
This PR creates 2 new workflows for managing JSON schemas generated from dbt artifacts.
### check schema
- generate JSON schema for dbt
- compare the generated schema to the relevant schema hosted on https://schemas.getdbt.com/ using a tool named https://pypi.org/project/deepdiff
- ignore changes to the default dbt version, any description fields, the default `dbt_schema_version`. We should probably not include default values for dbt version and `dbt_schema_version` in the JSON schema, will consider creating new issues for this
### publish schema
- generate JSON schema for dbt
- generate documentation for each JSON schema with a tool named https://pypi.org/project/json-schema-for-humans/
- generate an `index.html` to list all schema and relevant documentation (this is temporary! we should do this during the build process when deploying https://github.com/fishtown-analytics/schemas.getdbt.com to Netlify)
- push changes to https://github.com/fishtown-analytics/schemas.getdbt.com which kicks off a Netlify deployment (preview example https://deploy-preview-2--schemas-getdbt.netlify.app/)

For the record, I think this is a hacky approach, but I'm happy that there is some friction in place in case we should dbt with breaking schema changes. There is definitely more to do in this schema/versioning/deployment space