### PR TITLE
0.20.0rc2 release

### DIFF
--- a/releases/0.20/0.20.0rc2.txt
+++ b/releases/0.20/0.20.0rc2.txt
@@ -1,0 +1,21 @@
+commit: 8464c6c36f63961085157012452bdba980cea70b
+branch: 0.20.latest
+version: 0.20.0rc2
+
+A second release candidate for v0.20.0.
+
+### Fixes
+
+- Handle quoted values within test configs, such as `where` ([#3458](https://github.com/fishtown-analytics/dbt/issues/3458), [#3459](https://github.com/fishtown-analytics/dbt/pull/3459))
+
+### Docs
+
+- Display `tags` on exposures ([docs#194](https://github.com/fishtown-analytics/dbt-docs/issues/194), [docs#195](https://github.com/fishtown-analytics/dbt-docs/issues/195))
+
+### Under the hood
+
+- Swap experimental parser implementation to use Rust [#3497](https://github.com/fishtown-analytics/dbt/pull/3497)
+- Dispatch the core SQL statement of the new test materialization, to benefit adapter maintainers ([#3465](https://github.com/fishtown-analytics/dbt/pull/3465), [#3461](https://github.com/fishtown-analytics/dbt/pull/3461))
+- Minimal validation of yaml dictionaries prior to partial parsing ([#3246](https://github.com/fishtown-analytics/dbt/issues/3246), [#3460](https://github.com/fishtown-analytics/dbt/pull/3460))
+- Add partial parsing tests and improve partial parsing handling of macros ([#3449](https://github.com/fishtown-analytics/dbt/issues/3449), [#3505](https://github.com/fishtown-analytics/dbt/pull/3505))
+- Update project loading event data to include experimental parser information. ([#3438](https://github.com/fishtown-analytics/dbt/issues/3438), [#3495](https://github.com/fishtown-analytics/dbt/pull/3495))

--- a/scripts/release-pypath/builder/homebrew.py
+++ b/scripts/release-pypath/builder/homebrew.py
@@ -361,7 +361,7 @@ class HomebrewLocalBuilder(BaseHomebrewBuilder):
     def run_tests(self, formula_path: Path, audit: bool = True):
         self.uninstall_reinstall_basics(formula_path=formula_path, audit=audit)
         python_bin = self._get_env_python_path()
-        dev_requirements = self.dbt_path / "dev_requirements.txt"
+        dev_requirements = self.dbt_path / "dev-requirements.txt"
         stream_output([python_bin, "-m", "pip", "install", "-r", dev_requirements])
         env_path = python_bin.parent.parent
         runner = PytestRunner(env_path, self.dbt_path)

--- a/scripts/release-pypath/builder/native.py
+++ b/scripts/release-pypath/builder/native.py
@@ -239,7 +239,7 @@ def test_wheels(args=None):
 
     tester = WheelManager.from_env_info(env)
     requirements = env.get_dbt_requirements_file(str(release.version))
-    dev_requirements = env.dbt_dir / "dev_requirements.txt"
+    dev_requirements = env.dbt_dir / "dev-requirements.txt"
     tester.install(
         env.test_venv, requirements=requirements, dev_requirements=dev_requirements
     )


### PR DESCRIPTION
- 0.20.b1 and 0.20.rc1 were released from the `develop` branch but the branch `0.20.latest` was created after those releases, and `develop` has since diverged. This changes the release branch to `0.20.latest`.
- in version 0.20 we renamed dev requirements. Since a patch of 0.19 was last to be released, we have to rename dev requirements for this release.