### PR TITLE
quickfix to unblock 0.20.0rc2

### DIFF
--- a/scripts/release-pypath/builder/homebrew.py
+++ b/scripts/release-pypath/builder/homebrew.py
@@ -72,8 +72,9 @@ class HomebrewTemplate:
             if pkg.name == "dbt":
                 dbt_package = pkg
             # we can assume that anything starting with dbt- in a fresh
-            # venv is a dbt package, I hope
-            elif pkg.name.startswith("dbt-"):
+            # venv is a dbt package, except dbt-extractor.
+            # when adapter plugins get split up, this janky check will go away.
+            elif pkg.name.startswith("dbt-") and pkg.name != "dbt-extractor":
                 dbt_dependencies.append(pkg)
             else:
                 ext_dependencies.append(pkg)


### PR DESCRIPTION
adds check to exclude `dbt-extractor` from the list of dbt plugins.