### PR TITLE
[GitHub Release] Replace `::set-output` and fix path to download artifact

### DIFF
--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Generate Tag in Expected format
         id: set_tag
-        run: echo "::set-output name=tag::v${{ inputs.version_number }}"
+        run: echo "tag=v${{ inputs.version_number }}" >> $GITHUB_OUTPUT
 
       - name: Check out the repository
         uses: actions/checkout@v3
@@ -87,8 +87,8 @@ jobs:
           if [[ "$output" == "release not found" ]]
           then
             echo Release for tag ${{ steps.set_tag.outputs.tag }} does not exist
-            echo "::set-output name=exists::false"
-            echo "::set-output name=draft_exists::false"
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "draft_exists=false" >> $GITHUB_OUTPUT
             exit 0
           fi
           commit=$(jq -r '.targetCommitish' <<< "$output")
@@ -102,13 +102,13 @@ jobs:
           if [[ $isDraft == true ]] && [[ ${{ inputs.testing }} == false ]]
           then
             echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists in draft form.  Need to Publish.
-            echo "::set-output name=exists::false"
-            echo "::set-output name=draft_exists::true"
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "draft_exists=true" >> $GITHUB_OUTPUT
             exit 0
           fi
           echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists.  Skip GitHub release.
-          echo "::set-output name=exists::true"
-          echo "::set-output name=draft_exists::false"
+          echo "exists=true" >> $GITHUB_OUTPUT
+          echo "draft_exists=false" >> $GITHUB_OUTPUT
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -183,7 +183,7 @@ jobs:
           if ${{ contains(inputs.version_number, 'rc') ||  contains(inputs.version_number, 'b') }}
           then
             echo This is a prerelease
-            echo ::set-output name=prerelease::--prerelease
+            echo "prerelease=--prerelease" >> $GITHUB_OUTPUT
           else
             echo This is not a prerelease
           fi
@@ -194,7 +194,7 @@ jobs:
           if [[ ${{ inputs.testing }} == true ]]
           then
             echo This is a draft release
-            echo ::set-output name=draft::--draft
+            echo "draft=--draft" >> $GITHUB_OUTPUT 
           else
             echo This is not a draft release
           fi

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -172,7 +172,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.version_number }}
-          path: "."
+          path: "dist/"
 
       - name: Display structure of all downloaded files
         run: ls -R


### PR DESCRIPTION
**Description**: 
This pr resolves warnings that are related to the usage of`::set-output` command and fixes the path to where to download the build artifact.

Changelog:
- Replaced `::set-output` with `$GITHUB_OUTPUT`;
- Fix the path to where to download the build artifact.

