### PR TITLE
[GitHub Release] Polish workflow code

### DIFF
--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -95,7 +95,7 @@ jobs:
             title="Release for tag ${{ steps.set_tag.outputs.tag }} does not exist"
             echo "exists=false" >> $GITHUB_OUTPUT
             echo "draft_exists=false" >> $GITHUB_OUTPUT
-            echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title"
+            echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title::"
             exit 0
           fi
           commit=$(jq -r '.targetCommitish' <<< "$output")
@@ -140,7 +140,7 @@ jobs:
       - name: "Tag Exists, Skip GitHub Release Job"
         run: | 
           echo title="A tag already exists for ${{ needs.check-release-exists.outputs.tag }} and commit, skipping release."
-          echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title"
+          echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title::"
 
   audit-release-different-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -111,7 +111,7 @@ jobs:
           if [[ $isDraft == true ]] && [[ ${{ inputs.test_run }} == false ]]
           then
             title="Release tag ${{ steps.set_tag.outputs.tag }} already associated with the draft release."
-            message="Release workflow will publicize the associated release."
+            message="Release workflow will publish the associated release."
             echo "exists=false" >> $GITHUB_OUTPUT
             echo "draft_exists=true" >> $GITHUB_OUTPUT
             echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title::$message"
@@ -176,13 +176,13 @@ jobs:
           echo "::error title=${{ env.NOTIFICATION_PREFIX }}: $title::$message"
           exit 1
 
-  publicize-github-release:
+  publish-draft-release:
     runs-on: ubuntu-latest
     needs: [check-release-exists, audit-release-different-commit]
     if: inputs.test_run  == 'false' && needs.check-release-exists.outputs.draft_exists == 'true'
 
     steps:
-      - name: "Publicize Draft Release - ${{ needs.check-release-exists.outputs.tag }}"
+      - name: "Publish Draft Release - ${{ needs.check-release-exists.outputs.tag }}"
         run: |
           gh release edit $TAG --draft=false --repo ${{ env.REPO_LINK }}
         env:
@@ -225,7 +225,7 @@ jobs:
         run: |
           if [[ ${{ inputs.test_run }} == true ]]
           then
-            echo Release will be publihsed as draft
+            echo Release will be published as draft
             echo "draft=--draft" >> $GITHUB_OUTPUT 
           else
             echo This is not a draft release

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -95,7 +95,7 @@ jobs:
             title="Release for tag ${{ steps.set_tag.outputs.tag }} does not exist"
             echo "exists=false" >> $GITHUB_OUTPUT
             echo "draft_exists=false" >> $GITHUB_OUTPUT
-            echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title::"
+            echo "::notice ${{ env.NOTIFICATION_PREFIX }}: $title"
             exit 0
           fi
           commit=$(jq -r '.targetCommitish' <<< "$output")

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -173,7 +173,7 @@ jobs:
         run: |
           title="Tag ${{ steps.check_release_commit.outputs.tag_name }} already exists for this commit!"
           message="Cannot create a new tag for ${{ needs.check-release-exists.outputs.tag }} for the same commit"
-          echo "::warning title=${{ env.NOTIFICATION_PREFIX }}: $title::$message"
+          echo "::error title=${{ env.NOTIFICATION_PREFIX }}: $title::$message"
           exit 1
 
   publicize-github-release:
@@ -214,7 +214,7 @@ jobs:
         run: |
           if ${{ contains(inputs.version_number, 'rc') ||  contains(inputs.version_number, 'b') }}
           then
-            echo This is a prerelease
+            echo Release will be set as pre-release
             echo "prerelease=--prerelease" >> $GITHUB_OUTPUT
           else
             echo This is not a prerelease
@@ -225,11 +225,18 @@ jobs:
         run: |
           if [[ ${{ inputs.test_run }} == true ]]
           then
-            echo This is a draft release
+            echo Release will be publihsed as draft
             echo "draft=--draft" >> $GITHUB_OUTPUT 
           else
             echo This is not a draft release
           fi
+
+      - name: "GitHub Release Workflow Annotation"
+        id: draft
+        run: |
+          title="Release ${{ needs.check-release-exists.outputs.tag }}"
+          message="Configuration: ${{ steps.release_type.outputs.prerelease }} ${{ steps.draft.outputs.draft }}"
+          echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title::$message"
 
       - name: "Create New GitHub Release - ${{ needs.check-release-exists.outputs.tag }}"
         run: |

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -57,13 +57,13 @@ jobs:
   log-inputs:
     runs-on: ubuntu-latest
     steps:
-      - name: Print variables
+      - name: "[DEBUG] Print Variables"
         run: |
           echo The last commit sha in the release: ${{ inputs.sha }}
           echo The release version number:         ${{ inputs.version_number }}
           echo Expected Changlog path:             ${{ inputs.changelog_path }}
           echo Test run:                           ${{ inputs.test_run }}
-          echo REPO_LINK:                          ${{ env.REPO_LINK }}
+          echo Repo link:                          ${{ env.REPO_LINK }}
 
   check-release-exists:
     runs-on: ubuntu-latest
@@ -73,12 +73,9 @@ jobs:
       tag: ${{ steps.set_tag.outputs.tag }}
 
     steps:
-      - name: Generate tag in expected format
+      - name: "Generate Release Tag"
         id: set_tag
         run: echo "tag=v${{ inputs.version_number }}" >> $GITHUB_OUTPUT
-
-      - name: Check out the repository - {{ github.repository }}
-        uses: actions/checkout@v3
 
       # When the GitHub CLI doesn't find a release for the given tag, it will exit 1 with a
       # message of "release not found".  In our case, it's not an actual error, just a
@@ -87,10 +84,10 @@ jobs:
       # Also check if the release already exists is draft state.  If it does, and we are not
       # testing then we can publish that draft as is.  If it's in draft and we are testing, skip the
       # release.
-      - name: Check if release exists for tag
+      - name: "Check if release exists for tag ${{ steps.set_tag.outputs.tag }}"
         id: release_check
         run: |
-          output=$((gh release view ${{ steps.set_tag.outputs.tag }} --json isDraft,targetCommitish --repo $REPO) 2>&1) || true
+          output=$((gh release view ${{ steps.set_tag.outputs.tag }} --json isDraft,targetCommitish --repo ${{ env.REPO_LINK }}) 2>&1) || true
           if [[ "$output" == "release not found" ]]
           then
             echo Release for tag ${{ steps.set_tag.outputs.tag }} does not exist
@@ -116,7 +113,6 @@ jobs:
           echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists.  Skip GitHub release.
           echo "exists=true" >> $GITHUB_OUTPUT
           echo "draft_exists=false" >> $GITHUB_OUTPUT
-
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ env.REPO_LINK }}
@@ -133,7 +129,7 @@ jobs:
     if: needs.check-release-exists.outputs.exists == 'true'
 
     steps:
-      - name: Tag exists, skip GitHub Release job
+      - name: "Tag Exists, Skip GitHub Release Job"
         run: echo A tag already exists for ${{ needs.check-release-exists.outputs.tag }} and commit, skipping release
 
   audit-release-different-commit:
@@ -142,7 +138,7 @@ jobs:
     if: needs.check-release-exists.outputs.exists == 'false'
 
     steps:
-      - name: Check if release already exists for commit
+      - name: "Check If Release Already Exists For Commit"
         uses: cardinalby/git-get-release-action@v1
         id: check_release_commit
         env:
@@ -152,7 +148,7 @@ jobs:
           doNotFailIfNotFound: true # returns blank outputs when not found instead of error
           searchLimit: 15 # Since we only care about recent releases, speed up the process
 
-      - name: Print release details
+      - name: "[DEBUG] Print Release Details"
         run: |
           echo steps.check_release_commit.outputs.id:               ${{ steps.check_release_commit.outputs.id}}
           echo steps.check_release_commit.outputs.tag_name:         ${{ steps.check_release_commit.outputs.tag_name}}
@@ -160,7 +156,7 @@ jobs:
           echo steps.check_release_commit.outputs.prerelease:       ${{ steps.check_release_commit.outputs.prerelease}}
 
       # Since we already know a release for this tag does not exist, if we find anything it's for the wrong tag, exit
-      - name: Check if the tag matches the version number
+      - name: "Check If The Tag Matches The Version Number"
         if: steps.check_release_commit.outputs.id != ''
         run: |
           echo Tag "${{ steps.check_release_commit.outputs.tag_name}}" already exists for this commit!
@@ -173,13 +169,12 @@ jobs:
     if: inputs.test_run  == 'false' && needs.check-release-exists.outputs.draft_exists == 'true'
 
     steps:
-      - name: Publish a release that was previously a draft
+      - name: "Publicize Draft Release - ${{ needs.check-release-exists.outputs.tag }}"
         run: |
-          gh release edit $TAG --draft=false --repo $REPO
+          gh release edit $TAG --draft=false --repo ${{ env.REPO_LINK }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.check-release-exists.outputs.tag }}
-          REPO: ${{ env.REPO_LINK }}
 
   create-github-release:
     runs-on: ubuntu-latest
@@ -187,21 +182,21 @@ jobs:
     if: needs.check-release-exists.outputs.draft_exists == 'false'
 
     steps:
-      - name: Check out the repository - {{ github.repository }}
+      - name: "Checkout ${{ github.repository }} Commit ${{ inputs.sha }}"
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.sha }}
 
-      - name: Download artifact ${{ inputs.version_number }}
+      - name: "Download Artifact ${{ inputs.version_number }} To dist Folder"
         uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.version_number }}
           path: "dist/"
 
-      - name: Display structure of all downloaded files
+      - name: "[DEBUG] Display Structure Of All Downloaded Files"
         run: ls -R
 
-      - name: Set release type
+      - name: "Set Release Type"
         id: release_type
         run: |
           if ${{ contains(inputs.version_number, 'rc') ||  contains(inputs.version_number, 'b') }}
@@ -212,7 +207,7 @@ jobs:
             echo This is not a prerelease
           fi
 
-      - name: Set as draft release
+      - name: "Set As Draft Release"
         id: draft
         run: |
           if [[ ${{ inputs.test_run }} == true ]]
@@ -223,7 +218,7 @@ jobs:
             echo This is not a draft release
           fi
 
-      - name: Create new GitHub release - v${{ needs.check-release-exists.outputs.tag }}
+      - name: "Create New GitHub Release - ${{ needs.check-release-exists.outputs.tag }}"
         run: |
           gh release create $TAG ./dist/* --title "$TITLE" --notes-file $RELEASE_NOTES --target $COMMIT $PRERELEASE $DRAFT
         env:

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -27,16 +27,19 @@ on:
   workflow_call:
     inputs:
       sha:
+        description: The last commit sha in the release
         required: true
         type: string
       version_number:
+        description: The release version number (i.e. 1.0.0b1)
         required: true
         type: string
       changelog_path:
         description: Path to the changelog file for release notes
         required: true
         type: string
-      testing:
+      test_run:
+        description: Test run (Release will be published as draft)
         required: true
         type: string
     outputs:
@@ -56,7 +59,7 @@ jobs:
           echo The last commit sha in the release: ${{ inputs.sha }}
           echo The release version number: ${{ inputs.version_number }}
           echo Expected Changlog path: ${{ inputs.changelog_path }}
-          echo testing: ${{ inputs.testing }}
+          echo Test run: ${{ inputs.test_run }}
 
   check-release-exists:
     runs-on: ubuntu-latest
@@ -66,11 +69,11 @@ jobs:
       tag: ${{ steps.set_tag.outputs.tag }}
 
     steps:
-      - name: Generate Tag in Expected format
+      - name: Generate tag in expected format
         id: set_tag
         run: echo "tag=v${{ inputs.version_number }}" >> $GITHUB_OUTPUT
 
-      - name: Check out the repository
+      - name: Check out the repository - {{ github.repository }}
         uses: actions/checkout@v3
 
       # When the GitHub CLI doesn't find a release for the given tag, it will exit 1 with a
@@ -99,7 +102,7 @@ jobs:
             exit 1
           fi
           isDraft=$(jq -r '.isDraft' <<< "$output")
-          if [[ $isDraft == true ]] && [[ ${{ inputs.testing }} == false ]]
+          if [[ $isDraft == true ]] && [[ ${{ inputs.test_run }} == false ]]
           then
             echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists in draft form.  Need to Publish.
             echo "exists=false" >> $GITHUB_OUTPUT
@@ -113,7 +116,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log Job Outputs
+      - name: Log job outputs
         run: |
           echo exists: ${{ steps.release_check.outputs.exists }}
           echo draft_exists: ${{ steps.release_check.outputs.draft_exists }}
@@ -125,7 +128,7 @@ jobs:
     if: needs.check-release-exists.outputs.exists == 'true'
 
     steps:
-      - name: Tag Exists, Skip GitHub Release Job
+      - name: Tag exists, skip GitHub Release job
         run: echo A tag already exists for ${{ needs.check-release-exists.outputs.tag }} and commit, skipping release
 
   audit-release-different-commit:
@@ -144,7 +147,7 @@ jobs:
           doNotFailIfNotFound: true # returns blank outputs when not found instead of error
           searchLimit: 15 # Since we only care about recent releases, speed up the process
 
-      - name: Print Release Details
+      - name: Print release details
         run: |
           echo steps.check_release_commit.outputs.id ${{ steps.check_release_commit.outputs.id}}
           echo steps.check_release_commit.outputs.tag_name ${{ steps.check_release_commit.outputs.tag_name}}
@@ -159,13 +162,13 @@ jobs:
           echo Cannot create a new tag for "${{ needs.check-release-exists.outputs.tag }}" for the same commit.
           exit 1
 
-  github-release-update-status:
+  publicize-github-release:
     runs-on: ubuntu-latest
     needs: [check-release-exists, audit-release-different-commit]
-    if: inputs.testing  == 'false' && needs.check-release-exists.outputs.draft_exists == 'true'
+    if: inputs.test_run  == 'false' && needs.check-release-exists.outputs.draft_exists == 'true'
 
     steps:
-      - name: Check out the repository
+      - name: Check out the repository  - {{ github.repository }}
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.sha }}
@@ -177,18 +180,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.check-release-exists.outputs.tag }}
 
-  github-release-publish:
+  create-github-release:
     runs-on: ubuntu-latest
     needs: [check-release-exists, audit-release-different-commit]
     if: needs.check-release-exists.outputs.draft_exists == 'false'
 
     steps:
-      - name: Check out the repository
+      - name: Check out the repository - {{ github.repository }}
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.sha }}
 
-      - uses: actions/download-artifact@v3
+      - name: Download artifact ${{ inputs.version_number }}
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.version_number }}
           path: "dist/"
@@ -210,7 +214,7 @@ jobs:
       - name: Set as draft release
         id: draft
         run: |
-          if [[ ${{ inputs.testing }} == true ]]
+          if [[ ${{ inputs.test_run }} == true ]]
           then
             echo This is a draft release
             echo "draft=--draft" >> $GITHUB_OUTPUT 
@@ -218,7 +222,7 @@ jobs:
             echo This is not a draft release
           fi
 
-      - name: Create New GitHub Release
+      - name: Create new GitHub release - v${{ needs.check-release-exists.outputs.tag }}
         run: |
           gh release create $TAG ./dist/* --title "$TITLE" --notes-file $RELEASE_NOTES --target $COMMIT $PRERELEASE $DRAFT
         env:

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -52,6 +52,7 @@ permissions:
 
 env:
   REPO_LINK: ${{ github.server_url }}/${{ github.repository }}
+  NOTIFICATION_PREFIX: "[GitHub Release]"
 
 jobs:
   log-inputs:
@@ -161,7 +162,7 @@ jobs:
         run: |
           title="Tag ${{ steps.check_release_commit.outputs.tag_name }} already exists for this commit!"
           message="Cannot create a new tag for ${{ needs.check-release-exists.outputs.tag }} for the same commit"
-          echo "::warning title=$title::$message"
+          echo "::warning title=${{ env.NOTIFICATION_PREFIX }}: $title::$message"
           exit 1
 
   publicize-github-release:

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -165,6 +165,11 @@ jobs:
     if: inputs.testing  == 'false' && needs.check-release-exists.outputs.draft_exists == 'true'
 
     steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.sha }}
+
       - name: Publish a release that was previously a draft
         run: |
           gh release edit $TAG --draft=false
@@ -213,16 +218,7 @@ jobs:
             echo This is not a draft release
           fi
 
-      - name: Publish a release that was previously a draft
-        if: inputs.testing  == 'false' && needs.check-release-exists.outputs.draft_exists == 'true'
-        run: |
-          gh release edit $TAG --draft=false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.check-release-exists.outputs.tag }}
-
       - name: Create New GitHub Release
-        if: needs.check-release-exists.outputs.draft_exists == 'false'
         run: |
           gh release create $TAG ./dist/* --title "$TITLE" --notes-file $RELEASE_NOTES --target $COMMIT $PRERELEASE $DRAFT
         env:

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -57,9 +57,9 @@ jobs:
       - name: Print variables
         run: |
           echo The last commit sha in the release: ${{ inputs.sha }}
-          echo The release version number: ${{ inputs.version_number }}
-          echo Expected Changlog path: ${{ inputs.changelog_path }}
-          echo Test run: ${{ inputs.test_run }}
+          echo The release version number:         ${{ inputs.version_number }}
+          echo Expected Changlog path:             ${{ inputs.changelog_path }}
+          echo Test run:                           ${{ inputs.test_run }}
 
   check-release-exists:
     runs-on: ubuntu-latest
@@ -118,9 +118,9 @@ jobs:
 
       - name: Log job outputs
         run: |
-          echo exists: ${{ steps.release_check.outputs.exists }}
+          echo exists:       ${{ steps.release_check.outputs.exists }}
           echo draft_exists: ${{ steps.release_check.outputs.draft_exists }}
-          echo tag: ${{ steps.set_tag.outputs.tag }}
+          echo tag:          ${{ steps.set_tag.outputs.tag }}
 
   skip-github-release:
     runs-on: ubuntu-latest
@@ -149,10 +149,10 @@ jobs:
 
       - name: Print release details
         run: |
-          echo steps.check_release_commit.outputs.id ${{ steps.check_release_commit.outputs.id}}
-          echo steps.check_release_commit.outputs.tag_name ${{ steps.check_release_commit.outputs.tag_name}}
-          echo steps.check_release_commit.outputs.target_commitish ${{ steps.check_release_commit.outputs.target_commitish}}
-          echo steps.check_release_commit.outputs.prerelease ${{ steps.check_release_commit.outputs.prerelease}}
+          echo steps.check_release_commit.outputs.id:               ${{ steps.check_release_commit.outputs.id}}
+          echo steps.check_release_commit.outputs.tag_name:         ${{ steps.check_release_commit.outputs.tag_name}}
+          echo steps.check_release_commit.outputs.target_commitish: ${{ steps.check_release_commit.outputs.target_commitish}}
+          echo steps.check_release_commit.outputs.prerelease:       ${{ steps.check_release_commit.outputs.prerelease}}
 
       # Since we already know a release for this tag does not exist, if we find anything it's for the wrong tag, exit
       - name: Check if the tag matches the version number

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -65,6 +65,7 @@ jobs:
           echo Expected Changlog path:             ${{ inputs.changelog_path }}
           echo Test run:                           ${{ inputs.test_run }}
           echo Repo link:                          ${{ env.REPO_LINK }}
+          echo Notification prefix:                ${{ env.NOTIFICATION_PREFIX }}
 
   check-release-exists:
     runs-on: ubuntu-latest
@@ -91,29 +92,35 @@ jobs:
           output=$((gh release view ${{ steps.set_tag.outputs.tag }} --json isDraft,targetCommitish --repo ${{ env.REPO_LINK }}) 2>&1) || true
           if [[ "$output" == "release not found" ]]
           then
-            echo Release for tag ${{ steps.set_tag.outputs.tag }} does not exist
+            title="Release for tag ${{ steps.set_tag.outputs.tag }} does not exist"
             echo "exists=false" >> $GITHUB_OUTPUT
             echo "draft_exists=false" >> $GITHUB_OUTPUT
+            echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title"
             exit 0
           fi
           commit=$(jq -r '.targetCommitish' <<< "$output")
           if [[ $commit != ${{ inputs.sha }} ]]
           then
-            echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists for commit $commit!
-            echo Cannot create a new release for commit ${{ inputs.sha }}.  Exiting.
+            title="Release for tag ${{ steps.set_tag.outputs.tag }} already exists for commit $commit!"
+            message="Cannot create a new release for commit ${{ inputs.sha }}. Exiting."
+            echo "::error title=${{ env.NOTIFICATION_PREFIX }}: $title::$message"
             exit 1
           fi
           isDraft=$(jq -r '.isDraft' <<< "$output")
           if [[ $isDraft == true ]] && [[ ${{ inputs.test_run }} == false ]]
           then
-            echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists in draft form.  Need to Publish.
+            title="Release tag ${{ steps.set_tag.outputs.tag }} already associated with the draft release."
+            message="Release workflow will publicize the associated release."
             echo "exists=false" >> $GITHUB_OUTPUT
             echo "draft_exists=true" >> $GITHUB_OUTPUT
+            echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title::$message"
             exit 0
           fi
-          echo Release for tag ${{ steps.set_tag.outputs.tag }} already exists.  Skip GitHub release.
+          title="Release for tag ${{ steps.set_tag.outputs.tag }} already exists."
+          message="Skip GitHub Release Publishing."
           echo "exists=true" >> $GITHUB_OUTPUT
           echo "draft_exists=false" >> $GITHUB_OUTPUT
+          echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title::$message"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ env.REPO_LINK }}
@@ -131,7 +138,9 @@ jobs:
 
     steps:
       - name: "Tag Exists, Skip GitHub Release Job"
-        run: echo A tag already exists for ${{ needs.check-release-exists.outputs.tag }} and commit, skipping release
+        run: | 
+          echo title="A tag already exists for ${{ needs.check-release-exists.outputs.tag }} and commit, skipping release."
+          echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title"
 
   audit-release-different-commit:
     runs-on: ubuntu-latest
@@ -145,16 +154,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          commitSha: ${{inputs.sha}}
+          commitSha: ${{ inputs.sha }}
           doNotFailIfNotFound: true # returns blank outputs when not found instead of error
           searchLimit: 15 # Since we only care about recent releases, speed up the process
 
       - name: "[DEBUG] Print Release Details"
         run: |
-          echo steps.check_release_commit.outputs.id:               ${{ steps.check_release_commit.outputs.id}}
-          echo steps.check_release_commit.outputs.tag_name:         ${{ steps.check_release_commit.outputs.tag_name}}
-          echo steps.check_release_commit.outputs.target_commitish: ${{ steps.check_release_commit.outputs.target_commitish}}
-          echo steps.check_release_commit.outputs.prerelease:       ${{ steps.check_release_commit.outputs.prerelease}}
+          echo steps.check_release_commit.outputs.id:               ${{ steps.check_release_commit.outputs.id }}
+          echo steps.check_release_commit.outputs.tag_name:         ${{ steps.check_release_commit.outputs.tag_name }}
+          echo steps.check_release_commit.outputs.target_commitish: ${{ steps.check_release_commit.outputs.target_commitish }}
+          echo steps.check_release_commit.outputs.prerelease:       ${{ steps.check_release_commit.outputs.prerelease }}
 
       # Since we already know a release for this tag does not exist, if we find anything it's for the wrong tag, exit
       - name: "Check If The Tag Matches The Version Number"
@@ -229,5 +238,5 @@ jobs:
           TITLE: ${{ github.event.repository.name }} ${{ needs.check-release-exists.outputs.tag }}
           RELEASE_NOTES: ${{ inputs.changelog_path }}
           COMMIT: ${{ inputs.sha }}
-          PRERELEASE: ${{ steps.release_type.outputs.prerelease}}
-          DRAFT: ${{ steps.draft.outputs.draft}}
+          PRERELEASE: ${{ steps.release_type.outputs.prerelease }}
+          DRAFT: ${{ steps.draft.outputs.draft }}

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -159,9 +159,23 @@ jobs:
           echo Cannot create a new tag for "${{ needs.check-release-exists.outputs.tag }}" for the same commit.
           exit 1
 
-  github-release:
+  github-release-update-status:
     runs-on: ubuntu-latest
     needs: [check-release-exists, audit-release-different-commit]
+    if: inputs.testing  == 'false' && needs.check-release-exists.outputs.draft_exists == 'true'
+
+    steps:
+      - name: Publish a release that was previously a draft
+        run: |
+          gh release edit $TAG --draft=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.check-release-exists.outputs.tag }}
+
+  github-release-publish:
+    runs-on: ubuntu-latest
+    needs: [check-release-exists, audit-release-different-commit]
+    if: needs.check-release-exists.outputs.draft_exists == 'false'
 
     steps:
       - name: Check out the repository

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -92,10 +92,11 @@ jobs:
           output=$((gh release view ${{ steps.set_tag.outputs.tag }} --json isDraft,targetCommitish --repo ${{ env.REPO_LINK }}) 2>&1) || true
           if [[ "$output" == "release not found" ]]
           then
-            title="Release for tag ${{ steps.set_tag.outputs.tag }} does not exist"
+            title="Release for tag ${{ steps.set_tag.outputs.tag }} does not exist."
+            message="Check passed."
             echo "exists=false" >> $GITHUB_OUTPUT
             echo "draft_exists=false" >> $GITHUB_OUTPUT
-            echo "::notice ${{ env.NOTIFICATION_PREFIX }}: $title"
+            echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title::$message"
             exit 0
           fi
           commit=$(jq -r '.targetCommitish' <<< "$output")
@@ -138,9 +139,10 @@ jobs:
 
     steps:
       - name: "Tag Exists, Skip GitHub Release Job"
-        run: | 
-          echo title="A tag already exists for ${{ needs.check-release-exists.outputs.tag }} and commit, skipping release."
-          echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title::"
+        run: |
+          echo title="A tag already exists for ${{ needs.check-release-exists.outputs.tag }} and commit."
+          echo message="Skipping GitHub release."
+          echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title::$message"
 
   audit-release-different-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -159,8 +159,9 @@ jobs:
       - name: "Check If The Tag Matches The Version Number"
         if: steps.check_release_commit.outputs.id != ''
         run: |
-          echo Tag "${{ steps.check_release_commit.outputs.tag_name}}" already exists for this commit!
-          echo Cannot create a new tag for "${{ needs.check-release-exists.outputs.tag }}" for the same commit.
+          title="Tag ${{ steps.check_release_commit.outputs.tag_name }} already exists for this commit!"
+          message="Cannot create a new tag for ${{ needs.check-release-exists.outputs.tag }} for the same commit"
+          echo "::warning title=$title::$message"
           exit 1
 
   publicize-github-release:

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -2,9 +2,10 @@
 # Create a new release on GitHub and include any artifacts in the `/dist` directory of the GitHUb artifacts store.
 #
 # Inputs:
-#  sha: the commit to attach to this release
-#  version_number: version number for the release (ex: 1.2.3rc2)
-#  file_uploads: Newline-delimited globs of paths to assets to upload for release
+#  sha:            The commit to attach to this release
+#  version_number: The release version number (i.e. 1.0.0b1, 1.2.3rc2, 1.0.0)
+#  changelog_path: Path to the changelog file for release notes
+#  test_run:       Test run (Publish release as draft)
 #
 # **why?**
 # Reusable and consistent GitHub release process.
@@ -27,7 +28,7 @@ on:
   workflow_call:
     inputs:
       sha:
-        description: The last commit sha in the release
+        description: The commit to attach to this release
         required: true
         type: string
       version_number:
@@ -39,7 +40,7 @@ on:
         required: true
         type: string
       test_run:
-        description: Test run (Release will be published as draft)
+        description: Test run (Publish release as draft)
         required: true
         type: string
     outputs:

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -84,7 +84,7 @@ jobs:
       # Also check if the release already exists is draft state.  If it does, and we are not
       # testing then we can publish that draft as is.  If it's in draft and we are testing, skip the
       # release.
-      - name: "Check if release exists for tag ${{ steps.set_tag.outputs.tag }}"
+      - name: "Check If Release Exists For Tag ${{ steps.set_tag.outputs.tag }}"
         id: release_check
         run: |
           output=$((gh release view ${{ steps.set_tag.outputs.tag }} --json isDraft,targetCommitish --repo ${{ env.REPO_LINK }}) 2>&1) || true
@@ -117,7 +117,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ env.REPO_LINK }}
 
-      - name: Log job outputs
+      - name: "[DEBUG] Log Job Outputs"
         run: |
           echo exists:       ${{ steps.release_check.outputs.exists }}
           echo draft_exists: ${{ steps.release_check.outputs.draft_exists }}

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -50,6 +50,9 @@ on:
 permissions:
   contents: write
 
+env:
+  REPO_LINK: ${{ github.server_url }}/${{ github.repository }}
+
 jobs:
   log-inputs:
     runs-on: ubuntu-latest
@@ -60,6 +63,7 @@ jobs:
           echo The release version number:         ${{ inputs.version_number }}
           echo Expected Changlog path:             ${{ inputs.changelog_path }}
           echo Test run:                           ${{ inputs.test_run }}
+          echo REPO_LINK:                          ${{ env.REPO_LINK }}
 
   check-release-exists:
     runs-on: ubuntu-latest
@@ -86,7 +90,7 @@ jobs:
       - name: Check if release exists for tag
         id: release_check
         run: |
-          output=$((gh release view ${{ steps.set_tag.outputs.tag }} --json isDraft,targetCommitish) 2>&1) || true
+          output=$((gh release view ${{ steps.set_tag.outputs.tag }} --json isDraft,targetCommitish --repo $REPO) 2>&1) || true
           if [[ "$output" == "release not found" ]]
           then
             echo Release for tag ${{ steps.set_tag.outputs.tag }} does not exist
@@ -115,6 +119,7 @@ jobs:
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ env.REPO_LINK }}
 
       - name: Log job outputs
         run: |
@@ -168,17 +173,13 @@ jobs:
     if: inputs.test_run  == 'false' && needs.check-release-exists.outputs.draft_exists == 'true'
 
     steps:
-      - name: Check out the repository  - {{ github.repository }}
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.sha }}
-
       - name: Publish a release that was previously a draft
         run: |
-          gh release edit $TAG --draft=false
+          gh release edit $TAG --draft=false --repo $REPO
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.check-release-exists.outputs.tag }}
+          REPO: ${{ env.REPO_LINK }}
 
   create-github-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/_github-release.yml
+++ b/.github/workflows/_github-release.yml
@@ -232,7 +232,6 @@ jobs:
           fi
 
       - name: "GitHub Release Workflow Annotation"
-        id: draft
         run: |
           title="Release ${{ needs.check-release-exists.outputs.tag }}"
           message="Configuration: ${{ steps.release_type.outputs.prerelease }} ${{ steps.draft.outputs.draft }}"


### PR DESCRIPTION
**Description**:
We need to polish the workflow code to make it production ready.

**Changelog**:
- Split the `github-release` stage into `publish-github-release` and `create-github-release`;
- Replace the `checkout` task with passing `--repo` argument to GitHub CLI for the `publicize-github-release` and `check-release-exists` stages;
- Add a description to all workflow inputs;
- Rename `testing` input to `test_run`;
- Format workflow according to [guidelines](https://github.com/dbt-labs/dbt-core/blob/main/.github/_README.md);
- Updated notifications messages to use [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions) so that useful information will pop up on the workflow's annotation block.

**Work results**:
- Build and push draft release: https://github.com/dbt-labs/dbt-core-release-test/actions/runs/3639049102
- Publicize draft release: https://github.com/dbt-labs/dbt-core-release-test/actions/runs/3639107518
- Fail on tag audit: https://github.com/dbt-labs/dbt-core-release-test/actions/runs/3639137398
- Fail on commit audit: https://github.com/dbt-labs/dbt-core-release-test/actions/runs/3639166068