### PR TITLE
[Slack notification] Introduce workflow

### DIFF
--- a/.github/workflows/slack-post-notification.yml
+++ b/.github/workflows/slack-post-notification.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       notification_title:
-        default: "Release Proccess Status"
+        default: "Release Process Status"
         required: false
         type: string
     secrets:

--- a/.github/workflows/slack-post-notification.yml
+++ b/.github/workflows/slack-post-notification.yml
@@ -7,6 +7,10 @@ name: Post Slack Notification
 on:
   workflow_call:
     inputs:
+      notify_when:
+        default: "failure"
+        required: false
+        type: string
       notification_title:
         default: "Release Proccess Status"
         required: false
@@ -34,6 +38,7 @@ jobs:
       - name: "[DEBUG] Print Variables"
         run: |
           # WORKFLOW INPUTS
+          echo Notify when: ${{ inputs.notify_when }}
           echo Notification title:  ${{ inputs.notification_title }}
           # ENVIROMENT VARIABLES
           echo Notification prefix: ${{ env.NOTIFICATION_PREFIX }}
@@ -42,26 +47,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Dump GitHub context
-        id: github_context_step
-        run: echo '${{ toJSON(github) }}'
-
-      - name: Dump job context
-        run: echo '${{ toJSON(job) }}'
-
-      - name: Dump steps context
-        run: echo '${{ toJSON(steps) }}'
-
-      - name: Dump runner context
-        run: echo '${{ toJSON(runner) }}'
-
-      # - name: "Post Slack Notification"
-      #   uses: ravsamhq/notify-slack-action@v2.3.0
-      #   with:
-      #     status: ${{ job.status }}
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     notification_title: ${{ inputs.notification_title }}
-      #     message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}>"
-      #     footer: "<{run_url}|View Run>"
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: "Post Slack Notification"
+        uses: ravsamhq/notify-slack-action@v2.3.0
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          notification_title: ${{ inputs.notification_title }}
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}>"
+          footer: "<{run_url}|View Run>"
+          notify_when: ${{ inputs.notify_when }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/slack-post-notification.yml
+++ b/.github/workflows/slack-post-notification.yml
@@ -1,0 +1,67 @@
+# **what?**
+# **why?**
+# **when?**
+
+name: Post Slack Notification
+
+on:
+  workflow_call:
+    inputs:
+      notification_title:
+        default: "Release Proccess Status"
+        required: false
+        type: string
+    secrets:
+      SLACK_WEBHOOK_URL:
+        description: Slack app webhook url
+        required: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  NOTIFICATION_PREFIX: "[Slack Notification]"
+
+jobs:
+  log-inputs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "[DEBUG] Print Variables"
+        run: |
+          # WORKFLOW INPUTS
+          echo Notification title:  ${{ inputs.notification_title }}
+          # ENVIROMENT VARIABLES
+          echo Notification prefix: ${{ env.NOTIFICATION_PREFIX }}
+
+  slack-post-notification:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Dump GitHub context
+        id: github_context_step
+        run: echo '${{ toJSON(github) }}'
+
+      - name: Dump job context
+        run: echo '${{ toJSON(job) }}'
+
+      - name: Dump steps context
+        run: echo '${{ toJSON(steps) }}'
+
+      - name: Dump runner context
+        run: echo '${{ toJSON(runner) }}'
+
+      # - name: "Post Slack Notification"
+      #   uses: ravsamhq/notify-slack-action@v2.3.0
+      #   with:
+      #     status: ${{ job.status }}
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     notification_title: ${{ inputs.notification_title }}
+      #     message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}>"
+      #     footer: "<{run_url}|View Run>"
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
**Description**:
This pr introduces a `Slack notification` workflow.

_Workflow description_:
- The `notify-slack-action` action is wrapped into a reusable workflow so that we can reuse it in other workflows;
- The `notify_when` input controls when we push notifications to the Slack channel (_By default_: notify when workflows fail);
- The `notification_title` input will change the message title in the notification (_By default_: Release Process Status);

_Changelog_:
- Added `.github/workflows/slack-post-notification.yml`