### PR TITLE
[Release] Improve and fix reusable workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: "Audit Version And Parse Into Parts"
         id: semver
-        uses: dbt-labs/actions/parse-semver@dc183a8f07a756c6bb5e5fca63a2848b1fe781c8
+        uses: dbt-labs/actions/parse-semver@v1.1.0
         with:
           version: ${{ inputs.version_number }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,14 @@
 #       "s3://<s3_bucket>/<org>/<repo>/<artifact_folder>/<version>/<commit>/"
 #
 #   Notes:
-#   <artifact_folder> - resolves based on `test_run` input value.
+#   <artifact_folder> - resolves based on `test_run` and `nightly_release` inputs.
+#     nightly_release == true will use "nightly-releases"
+#     nightly_release == false resolves based on `test_run` input
 #     test_run == true  will use "artifacts_testing"
 #     test_run == false will use "artifacts"
 #
 #   Examples:
+#     nightly_release == true: "s3://core-team-artifacts/dbt-labs/dbt-core/nightly-releases/1.4.0a1.dev01112023+nightly/aaa410f17d300f1bde2cd67c03e48df135ab347b"
 #     test_run == true  : "s3://core-team-artifacts/dbt-labs/dbt-core/artifacts_testing/1.2.3/ce98e6f067d9fa63a9b213bf99ebaf0c29d2b7eb/"
 #     test_run == false : "s3://core-team-artifacts/dbt-labs/dbt-core/artifacts/1.2.3/ce98e6f067d9fa63a9b213bf99ebaf0c29d2b7eb/"
 #
@@ -28,6 +31,7 @@
 #  s3_bucket_name:       AWS S3 bucket name
 #  package_test_command: Command to use to check package runs
 #  test_run:             Test run (Bucket to upload the artifact)
+#  nightly_release:      Identifier that this is nightly release
 #
 # **why?**
 # Reusable and consistent build process.
@@ -112,6 +116,7 @@ jobs:
           echo The s3 bucket name:                 ${{ inputs.s3_bucket_name }}
           echo The package test command:           ${{ inputs.package_test_command }}
           echo Test run:                           ${{ inputs.test_run }}
+          echo Nightly release:                    ${{ inputs.nightly_release }}
           # ENVIRONMENT VARIABLES
           echo GitHub artifact retention days:     ${{ env.ARTIFACT_RETENTION_DAYS }}
           echo Amazon Web Services region:         ${{ env.AWS_REGION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,10 @@ jobs:
         run: |
           # Resolve folder to upload/check build artifact
           artifact_folder="artifacts"
-          if [[ ${{ inputs.test_run }} == true ]]
+          if [[ ${{ github.event_name }} == "schedule" ]]
+          then
+            artifact_folder="nightly-releases"
+          elif [[ ${{ inputs.test_run }} == true ]]
           then
             artifact_folder="artifacts_testing"
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,10 @@ on:
         required: false
         default: true
         type: boolean
+      nightly_release:
+        type: boolean
+        default: false
+        required: false
 
     # pass through secrets so every repo can have their own and won't depend on a name
     secrets:
@@ -125,7 +129,7 @@ jobs:
         run: |
           # Resolve folder to upload/check build artifact
           artifact_folder="artifacts"
-          if [[ ${{ github.event_name }} == "schedule" ]]
+          if [[ ${{ inputs.nightly_release }} == true ]]
           then
             artifact_folder="nightly-releases"
           elif [[ ${{ inputs.test_run }} == true ]]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,9 +78,9 @@ on:
         default: true
         type: boolean
       nightly_release:
-        type: boolean
-        default: false
         required: false
+        default: false
+        type: boolean
 
     # pass through secrets so every repo can have their own and won't depend on a name
     secrets:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -42,7 +42,7 @@ on:
       test_run:
         description: Test run (Publish release as draft)
         required: true
-        type: string
+        type: boolean
     outputs:
       tag:
         description: The path to the changelog for this version
@@ -180,7 +180,9 @@ jobs:
   publish-draft-release:
     runs-on: ubuntu-latest
     needs: [check-release-exists, audit-release-different-commit]
-    if: inputs.test_run  == 'false' && needs.check-release-exists.outputs.draft_exists == 'true'
+    if: >-
+       needs.check-release-exists.outputs.draft_exists == 'true' &&
+       inputs.test_run  == false
 
     steps:
       - name: "Publish Draft Release - ${{ needs.check-release-exists.outputs.tag }}"

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -181,8 +181,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check-release-exists, audit-release-different-commit]
     if: >-
-       needs.check-release-exists.outputs.draft_exists == 'true' &&
-       inputs.test_run  == false
+      needs.check-release-exists.outputs.draft_exists == 'true' &&
+      inputs.test_run  == false
 
     steps:
       - name: "Publish Draft Release - ${{ needs.check-release-exists.outputs.tag }}"

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: "Fetch PyPI Info For ${{ steps.semver.outputs.version }} Package"
         id: pypi_info
-        uses: dbt-labs/actions/py-package-info@c00eb536420d454ba5fdf90ac4571e360f0c7524
+        uses: dbt-labs/actions/py-package-info@users/alexander-smolyakov/py-package-introduce-retry-logic
         with:
           package: ${{ needs.sanitize-package-name.outputs.name }}
           version: ${{ steps.semver.outputs.version }}
@@ -183,7 +183,7 @@ jobs:
 
       - name: "Fetch PyPI Info For ${{ needs.sanitize-package-name.outputs.name }} Package"
         id: pypi_info
-        uses: dbt-labs/actions/py-package-info@c00eb536420d454ba5fdf90ac4571e360f0c7524
+        uses: dbt-labs/actions/py-package-info@users/alexander-smolyakov/py-package-introduce-retry-logic
         with:
           package: ${{ needs.sanitize-package-name.outputs.name }}
           version: ${{ steps.semver.outputs.version }}

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -81,13 +81,13 @@ jobs:
     steps:
       - name: "Audit Version And Parse Into Parts"
         id: semver
-        uses: dbt-labs/actions/parse-semver@dc183a8f07a756c6bb5e5fca63a2848b1fe781c8
+        uses: dbt-labs/actions/parse-semver@v1.1.0
         with:
           version: ${{ inputs.version_number }}
 
       - name: "Fetch PyPI Info For ${{ steps.semver.outputs.version }} Package"
         id: pypi_info
-        uses: dbt-labs/actions/py-package-info@users/alexander-smolyakov/py-package-introduce-retry-logic
+        uses: dbt-labs/actions/py-package-info@v1.1.0
         with:
           package: ${{ needs.sanitize-package-name.outputs.name }}
           version: ${{ steps.semver.outputs.version }}
@@ -178,13 +178,13 @@ jobs:
     steps:
       - name: "Audit Version And Parse Into Parts"
         id: semver
-        uses: dbt-labs/actions/parse-semver@dc183a8f07a756c6bb5e5fca63a2848b1fe781c8
+        uses: dbt-labs/actions/parse-semver@v1.1.0
         with:
           version: ${{ inputs.version_number }}
 
       - name: "Fetch PyPI Info For ${{ needs.sanitize-package-name.outputs.name }} Package"
         id: pypi_info
-        uses: dbt-labs/actions/py-package-info@users/alexander-smolyakov/py-package-introduce-retry-logic
+        uses: dbt-labs/actions/py-package-info@v1.1.0
         with:
           package: ${{ needs.sanitize-package-name.outputs.name }}
           version: ${{ steps.semver.outputs.version }}

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [sanitize-package-name, test-pypi-release, prod-pypi-release]
     # always run this step because one of the needs are always skipped.
-    if: ${{ success() }}
+    if: ${{ !failure() && !cancelled() }}
 
     steps:
       - name: "Audit Version And Parse Into Parts"

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -92,6 +92,7 @@ jobs:
           package: ${{ needs.sanitize-package-name.outputs.name }}
           version: ${{ steps.semver.outputs.version }}
           check-test-index: ${{ inputs.test_run }}
+          retries: 1
 
       - name: "Set Version Existence For Subsequent Jobs"
         # The above step will just use the latest version if the input version
@@ -100,7 +101,7 @@ jobs:
         id: version_existence
         run: |
           is_exists=false
-          if [[ ${{ steps.pypi_info.outputs.version }} == ${{ inputs.version_number }} ]]
+          if [[ ${{ steps.pypi_info.outputs.version }} == ${{ steps.semver.outputs.version }} ]]
           then
             is_exists=true
           fi
@@ -188,6 +189,7 @@ jobs:
           package: ${{ needs.sanitize-package-name.outputs.name }}
           version: ${{ steps.semver.outputs.version }}
           check-test-index: ${{ inputs.test_run }}
+          retries: 4
 
       - name: "Validate PyPI Info"
         id: is-version-available

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [sanitize-package-name, test-pypi-release, prod-pypi-release]
     # always run this step because one of the needs are always skipped.
-    if: ${{ !failure() && !cancelled() }}
+    if: always() && contains(needs.*.result, 'success')
 
     steps:
       - name: "Audit Version And Parse Into Parts"

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -29,8 +29,9 @@ on:
         required: true
         type: string
       test_run:
+        description: ""
         required: true
-        type: string
+        type: boolean
     # pass through secrets for both PyPi Test and Prod so they're always there
     secrets:
       PYPI_API_TOKEN:

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -242,7 +242,10 @@ jobs:
         id: variables
         run: |
           name="prep-release/"
-          if [[ ${{ inputs.test_run }} == true ]]
+          if [[ ${{ github.event_name }} == "schedule" ]]
+          then
+            name+="nightly-release/"
+          elif [[ ${{ inputs.test_run }} == true ]]
           then
             name+="test-run/"
           fi

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -55,6 +55,10 @@ on:
         required: false
         default: true
         type: boolean
+      nightly_release:
+        type: boolean
+        default: false
+        required: false
     outputs:
       final_sha:
         description: The new commit that includes the changelog and version bump.
@@ -242,7 +246,7 @@ jobs:
         id: variables
         run: |
           name="prep-release/"
-          if [[ ${{ github.event_name }} == "schedule" ]]
+          if [[ ${{ inputs.nightly_release }} == true  ]]
           then
             name+="nightly-release/"
           elif [[ ${{ inputs.test_run }} == true ]]

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -444,7 +444,7 @@ jobs:
 
                 if (INTEGRATION_TESTS_SECRETS_PREFIX) {
                   for (const [key, value] of Object.entries(secrets)) {
-                      if (key.startsWith('INTEGRATION_TESTS_SECRETS_PREFIX')) {
+                      if (key.startsWith(INTEGRATION_TESTS_SECRETS_PREFIX)) {
                           core.exportVariable(key, value)
                       }
                   }

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: "Audit Version And Parse Into Parts"
         id: semver
-        uses: dbt-labs/actions/parse-semver@dc183a8f07a756c6bb5e5fca63a2848b1fe781c8
+        uses: dbt-labs/actions/parse-semver@v1.1.0
         with:
           version: ${{ inputs.version_number }}
 

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -215,7 +215,7 @@ jobs:
         run: |
           # Send notification
           title="Skip changelog generation"
-          message="A changelog file already exists at ${{ needs.audit-changelog.outputs.exists }}, skipping generating changelog"
+          message="A changelog file already exists at ${{ needs.audit-changelog.outputs.changelog_path }}, skipping generating changelog"
           echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title::$message"
 
   skip-version-bump:

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -432,6 +432,32 @@ jobs:
       - name: "Setup Environment Variables - ./${{ inputs.env_setup_script_path }}"
         run: source ./${{ inputs.env_setup_script_path }}
 
+      - name: "Setup Environment Variables - Secrets Context"
+        uses: actions/github-script@v6
+        id: check-env
+        with:
+          result-encoding: string
+          script: |
+            try {
+                const { SECRETS_CONTEXT, INTEGRATION_TESTS_SECRETS_PREFIX } = process.env
+                const secrets = JSON.parse(SECRETS_CONTEXT)
+
+                if (INTEGRATION_TESTS_SECRETS_PREFIX) {
+                  for (const [key, value] of Object.entries(secrets)) {
+                      if (key.startsWith('INTEGRATION_TESTS_SECRETS_PREFIX')) {
+                          core.exportVariable(key, value)
+                      }
+                  }
+                } else {
+                  core.info("The INTEGRATION_TESTS_SECRETS_PREFIX env variable is empty or not defined, skipping the secrets setup.")
+                }
+            } catch (err) {
+                core.error("Error while reading or parsing the JSON")
+                core.setFailed(err)
+            }
+        env:
+          SECRETS_CONTEXT: ${{ toJson(secrets) }}
+
       - name: "Install Spark Dependencies"
         if: ${{ github.repository == 'dbt-labs/dbt-spark-release-test' }}
         run: |

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -7,6 +7,7 @@
 #  target_branch:         The branch that we will release from
 #  env_setup_script_path: Path to the environment setup script
 #  test_run:              Test run (The temp branch will be used for release)
+#  nightly_release:       Identifier that this is nightly release
 #
 # Outputs:
 #   final_sha:      The sha that will actually be released.  This can differ from the
@@ -18,8 +19,9 @@
 #  - For normal runs the temp branch will be removed once changes were merged to target branch;
 #  - For test runs we will keep temp branch and will use it for release;
 #  Naming strategy:
-#  - For normal runs: prep-release/${{ inputs.version_number }}_$GITHUB_RUN_ID
-#  - For test runs: prep-release/test-run/${{ inputs.version_number }}_$GITHUB_RUN_ID
+#  - For normal runs:      prep-release/${{ inputs.version_number }}_$GITHUB_RUN_ID
+#  - For test runs:        prep-release/test-run/${{ inputs.version_number }}_$GITHUB_RUN_ID
+#  - For nightly releases: prep-release/nightly-release/${{ inputs.version_number }}_$GITHUB_RUN_ID
 #
 # **why?**
 # Reusable and consistent GitHub release process.
@@ -95,6 +97,7 @@ jobs:
           echo The branch that we will release from: ${{ inputs.target_branch }}
           echo Path to the environment setup script: ${{ inputs.env_setup_script_path }}
           echo Test run:                             ${{ inputs.test_run }}
+          echo Nightly release:                      ${{ inputs.nightly_release }}
           # ENVIRONMENT VARIABLES
           echo Python target version:                ${{ env.PYTHON_TARGET_VERSION }}
           echo Notification prefix:                  ${{ env.NOTIFICATION_PREFIX }}


### PR DESCRIPTION
**Description**:
Improve and update reusable workflows.

**Changelog**:
_Version Bump and Changelog Generation workflow_:
- Added `nightly_release` input;
- Update workflow to respect `nightly_release` input;
- Added `Setup Environment Variables - Secrets Context` step to setup secrets for integration tests;

_Build workflow_:
- Added `nightly_release` input;
- Update workflow to respect `nightly_release` input;

_GitHub Release workflow_:
- Change the type for the `test_run` input to avoid typecast to string;
- Fix the `publish-draft-release` stage condition to respect the `test_run` input type;

_PyPI release workflow_:
- Change the type for the `test_run` input to avoid typecast to string;
- Fix the `Set Version Existence For Subsequent Jobs` step to compare the normalized version with the version from PyPI;
- Set `retries` input for `py-package-info` GH action;
- Fix the `validate-package-available-pyp` stage: replaced the `success()` since it will not work in our case since one of the jobs will be skipped, and this condition will not be evaluated as `true`.

**Related PR**:
- dbt-labs/actions/pull/60