### PR TITLE
[Release Preparation]  Update `Generate Release Changelog` script

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -306,8 +306,11 @@ jobs:
           if [[ ${{ needs.audit-changelog.outputs.is_prerelease }} -eq 1 ]]
           then
             changie batch ${{ needs.audit-changelog.outputs.base_version }} --move-dir '${{ needs.audit-changelog.outputs.base_version }}' --prerelease ${{ needs.audit-changelog.outputs.prerelease }}
-          else
+          elif [[ -d ".changes/${{ needs.audit-changelog.outputs.base_version }}" ]]
+          then
             changie batch ${{ needs.audit-changelog.outputs.base_version }} --include '${{ needs.audit-changelog.outputs.base_version }}' --remove-prereleases
+          else # releasing a final patch with no prereleases
+            changie batch ${{ needs.audit-changelog.outputs.base_version }}
           fi
           changie merge
           git status


### PR DESCRIPTION
**Description**:
We need to update the `Generate Release Changelog` script to respect the case when we release a patch without prerelease. In this case, we don't have a folder with a changelog, and this line cause failure:
https://github.com/dbt-labs/dbt-release/blob/d31e54238f04d86b5db7f22aec20aaeda52060fa/.github/workflows/release-prep.yml#L310

To avoid such an issue, we need to check if that related folder exists and, if not, doesn't include it.

_Changelog_:
- `Generate Release Changelog` script updated to check that folder `./changes/<base_version>` exists before running the `changie batch` command;