### PR TITLE
[Release] Rework repo name check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,7 +281,7 @@ jobs:
           python-version: ${{ env.PYTHON_TARGET_VERSION }}
 
       - name: "Install Spark Dependencies"
-        if: ${{ github.repository == 'dbt-labs/dbt-spark-release-test' }}
+        if: ${{ contains(github.repository, 'dbt-labs/dbt-spark') }}
         run: |
           sudo apt-get install libsasl2-dev
 

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -286,7 +286,7 @@ jobs:
           ref: ${{ needs.create-temp-branch.outputs.branch_name }}
 
       - name: "Install Spark Dependencies"
-        if: ${{ github.repository == 'dbt-labs/dbt-spark-release-test' }}
+        if: ${{ contains(github.repository, 'dbt-labs/dbt-spark') }}
         run: |
           sudo apt-get install libsasl2-dev
 
@@ -399,7 +399,7 @@ jobs:
           ref: ${{ needs.create-temp-branch.outputs.branch_name }}
 
       - name: "Install Spark Dependencies"
-        if: ${{ github.repository == 'dbt-labs/dbt-spark-release-test' }}
+        if: ${{ contains(github.repository, 'dbt-labs/dbt-spark') }}
         run: |
           sudo apt-get install libsasl2-dev
 
@@ -462,7 +462,7 @@ jobs:
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
 
       - name: "Install Spark Dependencies"
-        if: ${{ github.repository == 'dbt-labs/dbt-spark-release-test' }}
+        if: ${{ contains(github.repository, 'dbt-labs/dbt-spark') }}
         run: |
           sudo apt-get install libsasl2-dev
 
@@ -472,7 +472,7 @@ jobs:
           python-version: ${{ env.PYTHON_TARGET_VERSION }}
 
       - name: "Set Up Postgres (Linux)"
-        if: ${{ github.repository == 'dbt-labs/dbt-core-release-test' }}
+        if: ${{ contains(github.repository, 'dbt-labs/dbt-core') }}
         uses: ./.github/actions/setup-postgres-linux
 
       - name: "Install python tools"


### PR DESCRIPTION
**Description**:
In the current workflow implementation, we have specific steps for different repos. Currently, repo names are hardcoded with a `release-test` postfix. As a result, related steps are skipped when we try to run these workflows against prod repos. This pr replaces the equality operator with the `contains` expression so that workflow will work fine against both prod and release-test repos.

**Changelog**:
`build.yml`:
- Replace the equality operator with the `contains` expression

`release-prep.yml`:
- Replace the equality operator with the `contains` expression

**Related issue**:
- #53 