### PR TITLE
[PyPi Release] Increase retries for `py-package-info` action

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -189,7 +189,7 @@ jobs:
           package: ${{ needs.sanitize-package-name.outputs.name }}
           version: ${{ steps.semver.outputs.version }}
           check-test-index: ${{ inputs.test_run }}
-          retries: 4
+          retries: 8
 
       - name: "Validate PyPI Info"
         id: is-version-available


### PR DESCRIPTION
**Description**:
We need to increase retries attempts to make sure that the package index will have enough time to propagate info about the new package version.

**Changelog**:
- Retries bumped up: 4 -> 8