### PR TITLE
update changelog path

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -135,7 +135,7 @@ jobs:
           then
             path+="${{ steps.semver.outputs.base-version }}-${{ steps.semver.outputs.pre-release }}.md"
           else
-            path+="${{ steps.semver.outputs.version }}.md"
+            path+="${{ steps.semver.outputs.base-version }}.md"
           fi
           # Send notification
           echo "changelog_path=$path" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -157,9 +157,9 @@ jobs:
           title="Changelog exists"
           if [[ ${{ steps.set_existence.outputs.exists }} == true ]]
           then
-            message="Changelog file for ${{ inputs.version_number }} already exists"
+            message="Changelog file ${{ steps.set_path.outputs.changelog_path }} already exists"
           else
-            message="Changelog file for ${{ inputs.version_number }} doesn't exist"
+            message="Changelog file ${{ steps.set_path.outputs.changelog_path }} doesn't exist"
           fi
           echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title::$message"
 


### PR DESCRIPTION
Part of https://github.com/dbt-labs/dbt-core/issues/6906

Uses the base-version for the changelog to ensure we don't capture the `*.dev<date>` portion in release test versions.  The alternative is a lot more overly complex logic to account for the `*.dev<date>` portion of the version.

Pre releases are handles in the first part of the if statement.