### PR TITLE
add logic for spark safety

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -208,6 +208,20 @@ jobs:
         run: |
           echo up_to_date: ${{ steps.version-check.outputs.up_to_date }}
 
+  spark-safety-check:
+    runs-on: ubuntu-latest
+    needs: [audit-changelog, audit-version-in-code]
+    if: ${{ contains(github.repository, 'dbt-labs/dbt-spark') }}
+
+    steps:
+      - name: "Check version-bump has already run"
+        if: needs.audit-changelog.outputs.exists != 'true' || needs.audit-version-in-code.outputs.up_to_date != 'true'
+        run: |
+          title="Spark version-bump.yml check"
+          message="dbt-spark needs version-bump.yml run before running the release.  The changelog and/or version bump is not up to date."
+          echo "::error title=${{ env.NOTIFICATION_PREFIX }}: $title::$message"
+          exit 1
+
   skip-generate-changelog:
     runs-on: ubuntu-latest
     needs: [audit-changelog]

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -250,7 +250,7 @@ jobs:
 
   create-temp-branch:
     runs-on: ubuntu-latest
-    needs: [audit-changelog, audit-version-in-code]
+    needs: [audit-changelog, audit-version-in-code, spark-safety-check]
     if: needs.audit-changelog.outputs.exists == 'false' || needs.audit-version-in-code.outputs.up_to_date == 'false'
 
     outputs:


### PR DESCRIPTION
Because spark is still on CirclCI we need to run version_bump.yml separately still.  This ensures we fail out if the version doesn't match and/or the changelog still need to be generated.