### PR TITLE
update used gh actions ahead of set-output, node12 deprecation

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -152,7 +152,7 @@ jobs:
 
     steps:
       - name: "Check If Release Already Exists For Commit"
-        uses: cardinalby/git-get-release-action@v1
+        uses: cardinalby/git-get-release-action@v1.2.4
         id: check_release_commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -143,7 +143,7 @@ jobs:
           path: .
 
       - name: "Publish ${{ needs.sanitize-package-name.outputs.name }} v${{ inputs.version_number }} To Test PyPI"
-        uses: pypa/gh-action-pypi-publish@v1.6.4
+        uses: pypa/gh-action-pypi-publish@v1.8.5
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
@@ -165,7 +165,7 @@ jobs:
           path: .
 
       - name: "Publish ${{ needs.sanitize-package-name.outputs.name }} v${{ inputs.version_number }} To PyPI"
-        uses: pypa/gh-action-pypi-publish@v1.6.4
+        uses: pypa/gh-action-pypi-publish@v1.8.5
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -560,13 +560,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: "Merge Changes Into ${{ inputs.target_branch }}"
-        uses: everlytic/branch-merge@1.1.2
+        uses: everlytic/branch-merge@1.1.5
         with:
           source_ref: ${{ needs.create-temp-branch.outputs.branch_name }}
           target_branch: ${{ inputs.target_branch }}
           github_token: ${{ secrets.FISHTOWN_BOT_PAT }}
           commit_message_template: "[Automated] Merged {source_ref} into target {target_branch} during release process"
-      
+
       - name: "[Notification] Changes Merged into ${{ inputs.target_branch }}"
         run: |
           title="Changelog and Version Bump Branch Merge"


### PR DESCRIPTION
Description
Update versions of used Github Actions ahead of:

[node12 deprecation](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) (Summer 2023)
[set-output deprecation](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) fully disabled on 31st May 2023)