### PR TITLE
Unpin uses of parse-semver and py-package-info from actions v1.1.0

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -81,13 +81,13 @@ jobs:
     steps:
       - name: "Audit Version And Parse Into Parts"
         id: semver
-        uses: dbt-labs/actions/parse-semver@v1.1.0
+        uses: dbt-labs/actions/parse-semver@main
         with:
           version: ${{ inputs.version_number }}
 
       - name: "Fetch PyPI Info For ${{ steps.semver.outputs.version }} Package"
         id: pypi_info
-        uses: dbt-labs/actions/py-package-info@v1.1.0
+        uses: dbt-labs/actions/py-package-info@main
         with:
           package: ${{ needs.sanitize-package-name.outputs.name }}
           version: ${{ steps.semver.outputs.version }}
@@ -178,13 +178,13 @@ jobs:
     steps:
       - name: "Audit Version And Parse Into Parts"
         id: semver
-        uses: dbt-labs/actions/parse-semver@v1.1.0
+        uses: dbt-labs/actions/parse-semver@main
         with:
           version: ${{ inputs.version_number }}
 
       - name: "Fetch PyPI Info For ${{ needs.sanitize-package-name.outputs.name }} Package"
         id: pypi_info
-        uses: dbt-labs/actions/py-package-info@v1.1.0
+        uses: dbt-labs/actions/py-package-info@main
         with:
           package: ${{ needs.sanitize-package-name.outputs.name }}
           version: ${{ steps.semver.outputs.version }}


### PR DESCRIPTION
### Description

We need to use the latest versions of parse-semver and py-package-info from the actions repo. Instead of creating a new version, we have chosen to let the references track main instead.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-release/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
 
