### PR TITLE
Update dependabot to account for multiple directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/.github/workflows"
-    schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/latest-wrangler"
+    directory: "/"
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,17 @@
 version: 2
 updates:
-  # github dependencies
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/latest-wrangler"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+  - package-ecosystem: "docker"
+    directory: "/.github/actions/latest-wrangler"
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"


### PR DESCRIPTION
`dependabot` does not allow for multiple directories or recursion. Each directory requires an entry.