### PR TITLE
remove manual trigger, combine buildx aciton into job

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -13,27 +13,6 @@ permissions:
   packages: write
 
 on:
-  workflow_dispatch:
-    inputs:
-      package:
-        description: The package to release
-        type: choice
-        options:
-          - dbt-core
-          - dbt-bigquery
-          - dbt-postgres
-          - dbt-redshift
-          - dbt-snowflake
-          - dbt-spark
-        required: true
-      version_number:
-        description: The version number to release as a SemVer (e.g. 1.0.0b1, without `latest` or `v`)
-        required: true
-      test_run:
-        description: Test Run (don't publish)
-        type: boolean
-        default: true
-
   workflow_call:
     inputs:
       package:
@@ -51,12 +30,13 @@ on:
 
 jobs:
   version_metadata:
-    name: Get version metadata
+    name: "Get version metadata"
     runs-on: ubuntu-latest
     outputs:
       fully_qualified_tags: ${{ steps.tags.outputs.fully_qualified_tags }}
     steps:
-      - name: Get the tags to publish
+
+      - name: "Get the tags to publish"
         id: tags
         # this cannot be relative because this workflow is called from multiple repos
         # in addition to a manual trigger
@@ -66,35 +46,35 @@ jobs:
           new_version: ${{ inputs.version_number }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  setup_image_builder:
-    name: Set up Docker image builder
+
+  build_and_push:
+    name: "Set up Docker image builder, build and push"
     runs-on: ubuntu-latest
     needs: [version_metadata]
     steps:
-      - name: Set up Docker Buildx
+      - name: "Set up Docker Buildx"
         uses: docker/setup-buildx-action@v3
 
-  build_and_push:
-    name: Build images and push to GHCR
-    runs-on: ubuntu-latest
-    needs: [setup_image_builder, version_metadata]
-    steps:
-      - name: Get docker build arg
+      - name: "Get docker build arg"
         id: build_arg
         run: |
           BUILD_ARG_NAME=$(echo ${{ inputs.package }} | sed 's/\-/_/g')
-          BUILD_ARG_VALUE=$(echo ${{ inputs.package }} | sed 's/postgres/core/g')
+          if [[ $(echo "$version" | cut -d'.' -f2) > 7 ]]; then
+            BUILD_ARG_VALUE=$(echo ${{ inputs.package }})
+          else # for <= minor version 7, postgres lives inside core
+            BUILD_ARG_VALUE=$(echo ${{ inputs.package }} | sed 's/postgres/core/g')
+          fi
           echo "name=$BUILD_ARG_NAME" >> $GITHUB_OUTPUT
           echo "value=$BUILD_ARG_VALUE" >> $GITHUB_OUTPUT
 
-      - name: Log in to GHCR
+      - name: "Log in to GHCR"
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log publishing configuration
+      - name: "Log publishing configuration"
         shell: bash
         run: |
           echo Package:          ${{ inputs.package }}
@@ -103,7 +83,7 @@ jobs:
           echo Build Arg Name:   ${{ steps.build_arg.outputs.name }}
           echo Build Arg Value:  ${{ steps.build_arg.outputs.value }}
 
-      - name: Build and push `${{ inputs.package }}`
+      - name: "Build and push `${{ inputs.package }}`"
         if: ${{ !inputs.test_run }}
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
resolves #

### Description

Manual triggers won't work on this workflow since the contect would be in the wrong repo.

Remove the `workflow_dispatch` trigger & move the docker/setup-buildx-action@v3 into the main job.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-release/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
 
