### PR TITLE
Change internal build scheme for python patch versions.

### DIFF
--- a/.github/workflows/internal-archive-release.yml
+++ b/.github/workflows/internal-archive-release.yml
@@ -316,9 +316,9 @@ jobs:
           echo "[Debug] current_latest_version: ${current_latest_version}"
 
           echo ">>> Altering ${version_file}"
-          # Ensure a build+xxx where xxx is an integer is always present in versioning
+          # Ensure a ibuildXXX where XXX is an integer is always present in versioning
           # sed may be a no-op -- this is fine!
-          if [[ ${current_latest_version} =~ (.*build)([0-9]+)$ ]]; then
+          if [[ ${current_latest_version} =~ (.*ibuild)([0-9]+)$ ]]; then
               base="${BASH_REMATCH[1]}"
               number="${BASH_REMATCH[2]}"
               new_number=$((number + 1))
@@ -328,7 +328,7 @@ jobs:
                 sed -i "s/^package_version = .*$/package_version = \"${v}\"/" "${setup_file}"
               fi
           else
-              v="${version_in_file}+build1"
+              v="${version_in_file}ibuild1"
               tee <<< "version = \"${v}\"" "${version_file}"
               if [ -f "${setup_file}" ]; then
                 sed -i "s/^package_version = .*$/package_version = \"${v}\"/" "${setup_file}"


### PR DESCRIPTION
Despite official semver rules, Python has it's own opinions.

Official rules:
```
<valid semver> ::= <version core>
                 | <version core> "-" <pre-release>
                 | <version core> "+" <build>
                 | <version core> "-" <pre-release> "+" <build>
```

`ValueError: Invalid version: 1.6.13+build1`

To make this more complicated, remember dbt Labs ignores the `-`. 