### PR TITLE
Allow for new Docker releases with no previously published releases

### DIFF
--- a/.github/actions/latest-wrangler/main.py
+++ b/.github/actions/latest-wrangler/main.py
@@ -43,7 +43,7 @@ def _new_version_tags(new_version: Version, published_versions: List[Optional[Ve
         if patch.major == new_version.major and patch.minor == new_version.minor
     ]
 
-    # pre-releases don't get tagged with `latest`
+    # pre-releases don't get tagged with `latest` tags
     if new_version.is_prerelease:
         tags = [pinned]
 
@@ -55,7 +55,11 @@ def _new_version_tags(new_version: Version, published_versions: List[Optional[Ve
     elif new_version > max(published_versions):
         tags = [pinned, latest_minor, latest]
 
-    # this is not the overall latest release, but is still the latest minor release
+    # first minor releases are automatically the latest minor release
+    elif not published_patches:
+        tags = [pinned, latest_minor]
+
+    # this is a patch release that was released chronologically
     elif new_version > max(published_patches):
         tags = [pinned, latest_minor]
 

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -47,7 +47,7 @@ jobs:
       - name: "Get the tags to publish"
         id: tags
         # this cannot be relative because this workflow is called from multiple repos
-        uses: dbt-labs/dbt-release/.github/actions/latest-wrangler@latest-wrangler-new-docker
+        uses: dbt-labs/dbt-release/.github/actions/latest-wrangler@main
         with:
           package_name: ${{ inputs.package }}
           new_version: ${{ inputs.version_number }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -47,7 +47,7 @@ jobs:
       - name: "Get the tags to publish"
         id: tags
         # this cannot be relative because this workflow is called from multiple repos
-        uses: dbt-labs/dbt-release/.github/actions/latest-wrangler@main
+        uses: dbt-labs/dbt-release/.github/actions/latest-wrangler@latest-wrangler-new-docker
         with:
           package_name: ${{ inputs.package }}
           new_version: ${{ inputs.version_number }}


### PR DESCRIPTION
### Description

The `latest-wrangler` implementation assumes there are existing releases for a given Docker release. When using this for the new `dbt-postgres` Docker release, it failed because it could not compare the proposed release of `1.8.0` to anything because the published releases was empty.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-release/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue