### PR TITLE
Fix latest-wrangler

### DIFF
--- a/.github/actions/latest-wrangler/Dockerfile
+++ b/.github/actions/latest-wrangler/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim AS builder
+FROM python:3.9-slim AS builder
 ADD . /app
 WORKDIR /app
 
@@ -7,7 +7,7 @@ RUN pip install --target=/app requests packaging
 
 # A distroless container image with Python and some basics like SSL certificates
 # https://github.com/GoogleContainerTools/distroless
-FROM gcr.io/distroless/python3-debian10
+FROM gcr.io/distroless/python3.9-debian10
 COPY --from=builder /app /app
 WORKDIR /app
 ENV PYTHONPATH /app

--- a/.github/actions/latest-wrangler/Dockerfile
+++ b/.github/actions/latest-wrangler/Dockerfile
@@ -1,14 +1,10 @@
-FROM python:3.9-slim AS builder
+FROM python:3-slim AS builder
 ADD . /app
 WORKDIR /app
 
 # We are installing a dependency here directly into our app source dir
 RUN pip install --target=/app requests packaging
 
-# A distroless container image with Python and some basics like SSL certificates
-# https://github.com/GoogleContainerTools/distroless
-FROM gcr.io/distroless/python3.9-debian10
-COPY --from=builder /app /app
 WORKDIR /app
 ENV PYTHONPATH /app
 CMD ["/app/main.py"]

--- a/.github/actions/latest-wrangler/Dockerfile
+++ b/.github/actions/latest-wrangler/Dockerfile
@@ -5,6 +5,5 @@ WORKDIR /app
 # We are installing a dependency here directly into our app source dir
 RUN pip install --target=/app requests packaging
 
-WORKDIR /app
 ENV PYTHONPATH /app
-CMD ["/app/main.py"]
+CMD ["python", "/app/main.py"]

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -47,7 +47,7 @@ jobs:
       - name: "Get the tags to publish"
         id: tags
         # this cannot be relative because this workflow is called from multiple repos
-        uses: dbt-labs/dbt-release/.github/actions/latest-wrangler@main
+        uses: dbt-labs/dbt-release/.github/actions/latest-wrangler@er/pin-container
         with:
           package_name: ${{ inputs.package }}
           new_version: ${{ inputs.version_number }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -47,7 +47,7 @@ jobs:
       - name: "Get the tags to publish"
         id: tags
         # this cannot be relative because this workflow is called from multiple repos
-        uses: dbt-labs/dbt-release/.github/actions/latest-wrangler@er/pin-container
+        uses: dbt-labs/dbt-release/.github/actions/latest-wrangler@main
         with:
           package_name: ${{ inputs.package }}
           new_version: ${{ inputs.version_number }}


### PR DESCRIPTION
### Description

Make sure the container for the latest-wrangler action uses a single version of python.  Since this is just getting information and not actually building anything we can be slightly less optimized and just use the single container and drop the distroless one. 

Test run off branch: https://github.com/dbt-labs/dbt-core/actions/runs/11040717641/job/30669366369

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-release/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
 
