### PR TITLE
Fix duplicate post suffixes for internal archive release

### DIFF
--- a/.github/actions/next-cloud-release-version/get_next_release_version.py
+++ b/.github/actions/next-cloud-release-version/get_next_release_version.py
@@ -52,7 +52,7 @@ def main():
     parser.add_argument("--released_versions", type=str, help="comma delimited list of released versions")
     parser.add_argument("--target_version", help="Target version to compare against")
     args = parser.parse_args()
-    released_versions = list(filter(None, args.released_versions.split(",")))
+    released_versions = list(filter(None, args.released_versions.split(","))) if args.released_versions else []
     target_version = args.target_version
     latest_version = increment_latest_version(released_versions, target_version)
     print(f"{latest_version.major}.{latest_version.minor}.{latest_version.patch}{latest_version.prerelease[0]}")

--- a/.github/actions/next-cloud-release-version/get_next_release_version.py
+++ b/.github/actions/next-cloud-release-version/get_next_release_version.py
@@ -19,8 +19,15 @@ def increment_latest_version(released_versions: List[str], target_version: str) 
     target_version = Version.coerce(target_version)
     latest_version = target_version
     latest_version.prerelease = ("post0",)
+
+    # Function to extract the numeric part from prerelease tags like 'post01' or 'post2'
+    def extract_numeric_prerelease(prerelease: str) -> int:
+        match = re.match(r'(\D*)(\d+)', prerelease)  # Capture any non-digit prefix and the numeric part
+        return int(match.group(2)) if match else 0
+
     for version in released_versions:
         version = Version.coerce(version)
+
         # semantic_version does not handle build metadata, so we need to move it to the prerelease field
         if not version.prerelease and version.build:
             version.prerelease = version.build
@@ -29,7 +36,7 @@ def increment_latest_version(released_versions: List[str], target_version: str) 
                 version.major == latest_version.major
                 and version.minor == latest_version.minor
                 and version.patch == latest_version.patch
-                and version.prerelease > latest_version.prerelease
+                and extract_numeric_prerelease(version.prerelease[0]) > extract_numeric_prerelease(latest_version.prerelease[0])
         ):
             latest_version = version
 

--- a/.github/actions/next-cloud-release-version/get_next_release_version.py
+++ b/.github/actions/next-cloud-release-version/get_next_release_version.py
@@ -20,8 +20,10 @@ def increment_latest_version(released_versions: List[str], target_version: str) 
     latest_version = target_version
     latest_version.prerelease = ("post0",)
 
-    # Function to extract the numeric part from prerelease tags like 'post01' or 'post2'
-    def extract_numeric_prerelease(prerelease: str) -> int:
+    # Function to extract the numeric part from prerelease tags, even malformed ones
+    # like 'post01' or 'post2' if they end up in the archive
+    def get_post_number(version: str) -> int:
+        prerelease = version.prerelease[0]
         match = re.match(r'(\D*)(\d+)', prerelease)  # Capture any non-digit prefix and the numeric part
         return int(match.group(2)) if match else 0
 
@@ -36,7 +38,7 @@ def increment_latest_version(released_versions: List[str], target_version: str) 
                 version.major == latest_version.major
                 and version.minor == latest_version.minor
                 and version.patch == latest_version.patch
-                and extract_numeric_prerelease(version.prerelease[0]) > extract_numeric_prerelease(latest_version.prerelease[0])
+                and get_post_number(version) > get_post_number(latest_version)
         ):
             latest_version = version
 

--- a/.github/actions/next-cloud-release-version/get_next_release_version.py
+++ b/.github/actions/next-cloud-release-version/get_next_release_version.py
@@ -22,7 +22,7 @@ def increment_latest_version(released_versions: List[str], target_version: str) 
 
     # Function to extract the numeric part from prerelease tags, even malformed ones
     # like 'post01' or 'post2' if they end up in the archive
-    def get_post_number(version: str) -> int:
+    def get_post_number(version: Version) -> int:
         prerelease = version.prerelease[0]
         match = re.match(r'(\D*)(\d+)', prerelease)  # Capture any non-digit prefix and the numeric part
         return int(match.group(2)) if match else 0


### PR DESCRIPTION
### Description

Turns out we needed to work out an edge case with the way `post10` is alnum sorted, rather than numerically sorted. I added a helper function to solve this.

Also, I tried adding some simple default logic to avoid crash outs if no prior versions are stored in the repository, which could happen for newly archived adapters.

For testing, I just used the inputs from the actions themselves:
```
python get_next_release_version.py --released_version 1.8.0rc1+build1,1.8.0rc1+build2,1.9.0.post1+e5b28d67cf4b870da81674de3e1b84c4474a00a6,1.9.0.post10+78f86674bc726000686a484c4d2f0e2f9d350ed1,1.9.0.post2+2576a08379e248d393b9a698e58fac0d32c23648,1.9.0.post3+8ae3ec89f7bc829cfa9351100905e13bc42542ac,1.9.0.post4+d51584d606a9b56247f6c950006274c89ab7ab0c,1.9.0.post5+7fb4549abc52d53dfdbf02da423ee58cc8696ccc,1.9.0.post6+49623d7309bb64600d2ddb3f545ed6a9d8a0ddaf,1.9.0.post7+084674f68f52216a48e5c70a202666d3c2de1af4,1.9.0.post8+eea98443b21f6f3bdc3d297b727a0a9424d54d7b,1.9.0.post9+7dea1458ba4a63bafa2f4188768f1059b09dabdd,1.9.0a1+build1,1.9.0a1+build2,1.9.0a1+build3,1.9.0a1+build4,1.9.0a1+build5, --target_version 1.9.0b1
```
This now prints `1.9.0post11` as desired instead of (old behavior) `1.9.0post10`.

## Other tests

<img width="1237" alt="image" src="https://github.com/user-attachments/assets/9dcaf0fa-0eb6-4858-9fea-3802bd93e15f">

<img width="1237" alt="image" src="https://github.com/user-attachments/assets/28041414-d28e-4ea9-a898-c8ba0e154da3">


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-release/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue