### PR TITLE
replace setup.py reference with generic `build` call

### DIFF
--- a/.github/workflows/internal-archive-release.yml
+++ b/.github/workflows/internal-archive-release.yml
@@ -366,6 +366,7 @@ jobs:
             scripts/build-dist.sh
           else
             # Fallback onto to basic command
+            python -m pip install build
             python -m build 
           fi
 

--- a/.github/workflows/internal-archive-release.yml
+++ b/.github/workflows/internal-archive-release.yml
@@ -366,7 +366,7 @@ jobs:
             scripts/build-dist.sh
           else
             # Fallback onto to basic command
-            python setup.py sdist bdist_wheel
+            python -m build 
           fi
 
       #


### PR DESCRIPTION
now that dbt-databricks has moved to pyproject.toml our assumption that adapters have a setup.py no longer holds and we should move to a more setup agnostic command. 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-release/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
 
