### PR TITLE
INC-2124 stop using the core action and upgrade ubuntu

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -474,12 +474,30 @@ jobs:
         run: tox
 
   run-integration-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [create-temp-branch, generate-changelog-bump-version]
     if: inputs.env_setup_script_path != ''
 
     env:
       TOXENV: integration
+
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_PASSWORD: password
+          POSTGRES_USER: postgres
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
 
     steps:
       - name: "Checkout ${{ github.repository }} Branch ${{ needs.create-temp-branch.outputs.branch_name }}"
@@ -529,7 +547,12 @@ jobs:
 
       - name: "Set Up Postgres (Linux)"
         if: ${{ contains(github.repository, 'dbt-labs/dbt-core') }}
-        uses: ./.github/actions/setup-postgres-linux
+        run: |
+          ./test/setup_db.sh
+        env:
+          PGHOST: localhost
+          PGPORT: 5432
+          PGPASSWORD: password
 
       - name: "Install python tools"
         run: |


### PR DESCRIPTION
### Description

ubuntu 20.04 is EOL.  This upgrades the os and also stops using the shared core action to add permissions for testing.

Relates to https://github.com/dbt-labs/dbt-core/pull/11354

Need to test this with adapter releases.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-release/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
 
