### PR TITLE
bump docker build action for ubuntu EOL

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -76,7 +76,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Build `${{ inputs.package }}==${{ inputs.version_number }}`; push: ${{ !inputs.test_run }}"
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           file: ${{ inputs.dockerfile }}
           push: ${{ !inputs.test_run }}


### PR DESCRIPTION
### Description

docker/build-push-action@v5 used ubuntu 20.04.  It's EOL.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-release/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
 
