### PR TITLE
add back secret definition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,14 @@ on:
         required: false
         default: false
         type: boolean
+    #  still define these secrets to avoid breaking changes in calling workflows
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        description: "deprecated - DO NOT USE"
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        description: "deprecated - DO NOT USE"
+        required: false
 
 
 permissions:


### PR DESCRIPTION
### Description

You can't pass secrets into workflow when the secret isn't defined.  To prevent breaking changes (old versions of adapters also use this release) define the secrets even though we never use them.

Error in calling workflows
```
[Invalid workflow file: .github/workflows/release.yml#L154](https://github.com/dbt-labs/dbt-core/actions/runs/14221544502/workflow)
The workflow is not valid. .github/workflows/release.yml (Line: 154, Col: 26): Invalid secret, AWS_ACCESS_KEY_ID is not defined in the referenced workflow. .github/workflows/release.yml (Line: 155, Col: 30): Invalid secret, AWS_SECRET_ACCESS_KEY is not defined in the referenced workflow.
```

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-release/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
 
