### PR TITLE
be verbose in hatch

### DIFF
--- a/.github/workflows/build-hatch.yml
+++ b/.github/workflows/build-hatch.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: "Run Unit Tests"
         working-directory: ${{ inputs.hatch_directory }}
-        run: hatch run unit-tests
+        run: hatch -v run unit-tests
 
   build-packages:
     runs-on: ubuntu-latest
@@ -95,11 +95,11 @@ jobs:
 
       - name: "Build Distributions"
         working-directory: ${{ inputs.hatch_directory }}
-        run: hatch build
+        run: hatch -v build
 
       - name: "Check Wheel Distribution Descriptions"
         working-directory: ${{ inputs.hatch_directory }}
-        run: hatch run build:check-all
+        run: hatch -v run build:check-all
 
       - name: "Copy Distributions to Root"
         run: |

--- a/.github/workflows/release-prep-hatch.yml
+++ b/.github/workflows/release-prep-hatch.yml
@@ -145,7 +145,7 @@ jobs:
         if: inputs.needs_version_update == 'true'
         working-directory: ${{ inputs.hatch_directory }}
         run: |
-          hatch version ${{ inputs.version_number }}
+          hatch -v version ${{ inputs.version_number }}
           git status
 
       - name: "[Notification] Bump Version To ${{ inputs.version_number }}"
@@ -201,7 +201,7 @@ jobs:
 
       - name: "Run Unit Tests"
         working-directory: ${{ inputs.hatch_directory }}
-        run: hatch run unit-tests
+        run: hatch -v run unit-tests
 
   run-integration-tests:
     runs-on: ubuntu-24.04
@@ -278,4 +278,4 @@ jobs:
 
       - name: "Run tests"
         working-directory: ${{ inputs.hatch_directory }}
-        run: hatch run integration-tests
+        run: hatch -v run integration-tests

--- a/.github/workflows/release-prep-hatch.yml
+++ b/.github/workflows/release-prep-hatch.yml
@@ -144,8 +144,10 @@ jobs:
       - name: "Bump Version To ${{ inputs.version_number }}"
         if: inputs.needs_version_update == 'true'
         working-directory: ${{ inputs.hatch_directory }}
+        env:
+          VERSION_NUMBER: ${{ inputs.version_number }}
         run: |
-          hatch -v version ${{ inputs.version_number }}
+          hatch -v version "$VERSION_NUMBER"
           git status
 
       - name: "[Notification] Bump Version To ${{ inputs.version_number }}"


### PR DESCRIPTION
### Description

Adds verbosity to hatch commands do we can get more info on env, including all dependencies installed.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-release/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
 
