### PR TITLE
move db setup

### DIFF
--- a/.github/workflows/release-prep-hatch.yml
+++ b/.github/workflows/release-prep-hatch.yml
@@ -270,7 +270,7 @@ jobs:
       - name: "Set Up Postgres (dbt-core)"
         if: ${{ contains(github.repository, 'dbt-labs/dbt-core') }}
         run: |
-          ./test/setup_db.sh
+          ./scripts/setup_db.sh
         env:
           PGHOST: localhost
           PGPORT: 5432

--- a/.github/workflows/release-prep-legacy.yml
+++ b/.github/workflows/release-prep-legacy.yml
@@ -277,6 +277,7 @@ jobs:
       - name: "Set Up Postgres (dbt-core)"
         if: ${{ contains(github.repository, 'dbt-labs/dbt-core') }}
         run: |
+          # this code moved from test/setup_db.sh to scripts/setup_db.sh in version 1.11 when we started to use hatch
           ./test/setup_db.sh
         env:
           PGHOST: localhost


### PR DESCRIPTION
### Description

`test/setup_db.sh` moved to `scripts/setup_db.sh` at the same time we moved to hatch so this reflects that change.

Pending backport of the script move to 1.11.latest.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-release/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
 
