### PR TITLE
Fix dbt-* dependency scrub in setup.py for standalone variable assignments

### DIFF
--- a/.github/workflows/internal-archive-release.yml
+++ b/.github/workflows/internal-archive-release.yml
@@ -352,7 +352,7 @@ jobs:
             # Scrub any dependency specification from a package prefixed with "dbt-" 
             # but preserve the package name, for example:
             # "dbt-postgres>=0.19.0" -> "dbt-postgres"
-            sed -i "s/\(dbt-[a-z]*\)\(.*[>=~@].*\)\",/\1\",/" "${setup_file}"
+            sed -i "s/\(dbt-[a-z]*\)\([>=~@!<][^\"]*\)\"/\1\"/" "${setup_file}"
           fi
           
           # Handle pyproject.toml if it exists


### PR DESCRIPTION
## Summary

The `setup.py` dependency-scrub sed in `internal-archive-release.yml` required a trailing `",` (quote + comma), so it silently skipped any `dbt-*` dependency declared as a standalone variable assignment.

Concretely, [dbt-synapse's setup.py:18](https://github.com/microsoft/dbt-synapse/blob/master/setup.py#L18) declares:

```python
dbt_fabric_requirement = "dbt-fabric>=1.8.0,<1.10"
```

That line ends with `"` only, so the version pin was passing through to the internal pypi publish unchanged.

## Fix

Align the `setup.py` regex with the `pyproject.toml` regex right below it: stop at the closing quote (`[^"]*"`) instead of requiring `",`, and broaden the leading version-specifier char class to include `<` and `!`.

Verified locally against:
- `dbt-fabric>=1.8.0,<1.10` (the dbt-synapse case)
- `dbt-postgres>=0.19.0` (original example in the comment)
- `dbt-core~=1.5.0`
- `dbt-bigquery@git+https://...`
- already-bare `dbt-redshift` (untouched)
- non-dbt deps like `requests>=2.0` (untouched)

## Test plan

- [ ] Trigger an internal release for `dbt-synapse` and confirm the published wheel's `install_requires` lists `dbt-fabric` with no version specifier.
- [ ] Confirm at least one previously-working adapter (e.g. `dbt-postgres`) still scrubs correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)