### PR TITLE
Migrate dbt-core branch references from main to 1.latest

### DIFF
--- a/.github/workflows/internal-archive-release.yml
+++ b/.github/workflows/internal-archive-release.yml
@@ -247,7 +247,7 @@ jobs:
 
     uses: "dbt-labs/dbt-postgres/.github/workflows/integration-tests.yml@main"
     with:
-      dbt_core_branch: "main"
+      dbt_core_branch: "1.latest"
       dbt_adapters_branch: "main"
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,13 +62,13 @@ A deep understanding of these tools in not required to effectively contribute to
 ## Running `dbt-release` in development
 
 - Install pre-commit ([docs](https://pre-commit.com/#installation))
-- Use the following [guidelines](https://github.com/dbt-labs/dbt-core/blob/main/.github/_README.md) during development
+- Use the following [guidelines](https://github.com/dbt-labs/dbt-core/blob/1.latest/.github/_README.md) during development
 - Each workflow should be self-documented
 
 
 ### Running `dbt-release`
 
-Workflows in this repository are all triggered with a `workflow_call` so to test your changes you will need to set up a workflow in another repository to trigger your the modified workflow on your branch or fork.  [release.yml](https://github.com/dbt-labs/dbt-core/blob/main/.github/workflows/release.yml) is what we use to trigger all the workflows in this repository and is a good example of how to trigger them.
+Workflows in this repository are all triggered with a `workflow_call` so to test your changes you will need to set up a workflow in another repository to trigger your the modified workflow on your branch or fork.  [release.yml](https://github.com/dbt-labs/dbt-core/blob/1.latest/.github/workflows/release.yml) is what we use to trigger all the workflows in this repository and is a good example of how to trigger them.
 
 
 ## Testing
@@ -104,7 +104,7 @@ To use workflows inside other workflows, you can use the `main` branch or specif
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 ```
 
-**Example**: <https://github.com/dbt-labs/dbt-core/blob/main/.github/workflows/release.yml>
+**Example**: <https://github.com/dbt-labs/dbt-core/blob/1.latest/.github/workflows/release.yml>
 
 ## Debugging
 


### PR DESCRIPTION
## Summary

- Updates the hard-coded `dbt_core_branch` input in `internal-archive-release.yml` from `main` to `1.latest`
- Updates dbt-core documentation URLs in `CONTRIBUTING.md` from `/blob/main/` to `/blob/1.latest/`

## Changes

- [.github/workflows/internal-archive-release.yml:250](https://github.com/dbt-labs/dbt-release/blob/migrate-dbt-core-branch-to-1-latest/.github/workflows/internal-archive-release.yml#L250) — `dbt_core_branch: "1.latest"`
- `CONTRIBUTING.md` — 3 URL references to `dbt-labs/dbt-core/blob/...` repointed to `1.latest`

## Not changed

- `dbt_adapters_branch: "main"` (adjacent line) — different repo, not in scope
- `contains(github.repository, 'dbt-labs/dbt-core')` checks in `release-prep-hatch.yml` / `release-prep-legacy.yml` — repo-name checks, not branches
- S3 artifact paths and prose mentioning `dbt-core` — not branch references
- Other `@main` workflow refs (`dbt-adapters`, `dbt-postgres`, `dbt-release`, `dbt-labs/actions`) — different repos

## Test plan

- [ ] Confirm `1.latest` branch exists on `dbt-labs/dbt-core`
- [ ] Confirm `dbt-labs/dbt-postgres` integration-tests workflow accepts `1.latest` as `dbt_core_branch`
- [ ] Verify the next internal archive release run picks up the new branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)